### PR TITLE
bench: record ping-pong saturation

### DIFF
--- a/benchmark/barback/README.md
+++ b/benchmark/barback/README.md
@@ -69,6 +69,8 @@ BENCH_VARIANT=hypermeow BENCH_SESSIONS=2000 ./run-client-memory.sh
 
 Results are written to `results/`. PostgreSQL statement statistics are reset on the authenticated connection event, before Barback's benchmark warmup. The report includes the top WhatsMeow queries, total statement calls and execution time, send and upload latency percentiles, throughput, Go heap/GC/CPU data, peak RSS, process and block I/O, temporary-file peaks and cleanup, network traffic, failures, message-shape counts, and history-sync counts. `session_runtime` begins at the connected event and includes history sync; `workload_runtime` begins at the first live benchmark message. Docker stats include the whole container lifetime. Network timings are local-container transport measurements, not internet latency.
 
+When `BENCH_WORKERS` is greater than one, messages are assigned to chat-affine worker queues. Different chats run concurrently, while messages for one Signal session remain ordered. Set `BARBACK_LOG_LEVEL=info` when validating ping-pong throughput so the final decrypted-pong count and wire RTT are visible in the Barback logs.
+
 The frozen three-repeat comparison is summarized in `results/system-comparison.md`; its 45 JSON reports and 45 Docker-stat streams remain alongside it.
 
 Set `MEM_PROFILE_PATH=/results/run.heap.pb.gz` to capture a full-rate Go allocation profile. Profiling changes runtime cost, so compare profiles with each other rather than with ordinary benchmark timings. Inspect cumulative allocations with `go tool pprof -top -alloc_space results/run.heap.pb.gz` and retained heap with `go tool pprof -top -inuse_space results/run.heap.pb.gz`.

--- a/benchmark/barback/cmd/bench/main.go
+++ b/benchmark/barback/cmd/bench/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/store/sqlstore"
+	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
@@ -145,7 +146,7 @@ type runner struct {
 	startedAt  atomic.Int64
 	finishedAt atomic.Int64
 	done       chan struct{}
-	jobs       chan *events.Message
+	jobs       []chan *events.Message
 
 	latencyMu       sync.Mutex
 	latencies       []float64
@@ -173,13 +174,21 @@ func main() {
 	if cfg.MemProfilePath != "" {
 		runtime.MemProfileRate = 1
 	}
+	workerCount := int(cfg.Workload.Workers)
+	queueCapacity := (4096 + workerCount - 1) / workerCount
+	if queueCapacity < 512 {
+		queueCapacity = 512
+	}
 	r := &runner{
 		cfg:            cfg,
 		done:           make(chan struct{}),
-		jobs:           make(chan *events.Message, 4096),
+		jobs:           make([]chan *events.Message, workerCount),
 		latencies:      make([]float64, 0, cfg.Total),
 		messageTypes:   make(map[string]int64),
 		failureReasons: make(map[string]int64),
+	}
+	for i := range r.jobs {
+		r.jobs[i] = make(chan *events.Message, queueCapacity)
 	}
 	res, runErr := r.run()
 	if cfg.MemProfilePath != "" {
@@ -358,8 +367,8 @@ func (r *runner) run() (result, error) {
 
 	workerCtx, stopWorkers := context.WithCancel(ctx)
 	defer stopWorkers()
-	for range r.cfg.Workload.Workers {
-		go r.sendWorker(workerCtx, client)
+	for _, jobs := range r.jobs {
+		go r.sendWorker(workerCtx, client, jobs)
 	}
 
 	if err = client.ConnectContext(ctx); err != nil {
@@ -412,8 +421,9 @@ func (r *runner) handler(client *whatsmeow.Client) whatsmeow.EventHandler {
 			}
 			r.startOnce.Do(r.startMetrics)
 			r.received.Add(1)
+			jobs := r.jobs[jobShard(event.Info.Chat, len(r.jobs))]
 			select {
-			case r.jobs <- event:
+			case jobs <- event:
 			default:
 				r.overflows.Add(1)
 				r.failed.Add(1)
@@ -484,12 +494,26 @@ func (r *runner) scanQR(code string) {
 	}
 }
 
-func (r *runner) sendWorker(ctx context.Context, client *whatsmeow.Client) {
+func jobShard(jid types.JID, count int) int {
+	const offset64 = uint64(14695981039346656037)
+	const prime64 = uint64(1099511628211)
+	hash := offset64
+	for i := range jid.User {
+		hash = (hash ^ uint64(jid.User[i])) * prime64
+	}
+	for i := range jid.Server {
+		hash = (hash ^ uint64(jid.Server[i])) * prime64
+	}
+	hash = (hash ^ uint64(jid.Device)) * prime64
+	return int(hash % uint64(count))
+}
+
+func (r *runner) sendWorker(ctx context.Context, client *whatsmeow.Client, jobs <-chan *events.Message) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case msg := <-r.jobs:
+		case msg := <-jobs:
 			sequence := r.messageSequence.Add(1) - 1
 			outgoing, category, mediaBytes, uploadDuration, err := buildWorkloadMessage(ctx, client, string(msg.Info.ID), sequence, r.cfg.Workload.MessageProfile)
 			if uploadDuration > 0 {

--- a/benchmark/barback/cmd/bench/main_test.go
+++ b/benchmark/barback/cmd/bench/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 	"time"
+
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestLoadConfigWorkload(t *testing.T) {
@@ -82,5 +85,26 @@ func TestSnapshotUsesMessageCompletionBoundary(t *testing.T) {
 	}
 	if result.ThroughputPerSec != 0.125 {
 		t.Fatalf("unexpected throughput: %f", result.ThroughputPerSec)
+	}
+}
+
+func TestJobShardKeepsChatOrdered(t *testing.T) {
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	first := jobShard(chat, 64)
+	for range 100 {
+		if got := jobShard(chat, 64); got != first {
+			t.Fatalf("chat moved shards: got %d, want %d", got, first)
+		}
+	}
+}
+
+func TestJobShardDistributesChats(t *testing.T) {
+	seen := make(map[int]struct{})
+	for i := range 64 {
+		chat := types.NewJID("1555123"+strconv.Itoa(i), types.DefaultUserServer)
+		seen[jobShard(chat, 64)] = struct{}{}
+	}
+	if len(seen) < 32 {
+		t.Fatalf("chat sharding is too concentrated: %d shards", len(seen))
 	}
 }

--- a/benchmark/barback/compose.yaml
+++ b/benchmark/barback/compose.yaml
@@ -75,6 +75,7 @@ services:
         condition: service_completed_successfully
     environment:
       MEDIA_CONN_HOST: barback:8080
+      RUST_LOG: ${BARBACK_LOG_LEVEL:-info}
     healthcheck:
       test: ["CMD", "/usr/local/bin/barback", "--healthcheck", "--port", "8080"]
       interval: 1s

--- a/benchmark/barback/results/maxrate-hypermeow-final-1700.json
+++ b/benchmark/barback/results/maxrate-hypermeow-final-1700.json
@@ -1,0 +1,268 @@
+{
+  "variant": "hypermeow-final",
+  "revision": "fc8c62034115b587bd5102834ee57ed1bdbda997",
+  "started_at": "2026-08-06T22:39:50.83347909Z",
+  "completed": true,
+  "target_messages": 17064,
+  "workload": {
+    "scenario": "ping-pong-1700",
+    "mode": "dm",
+    "rate": 1700,
+    "senders": 64,
+    "workers": 64,
+    "warmup_ms": 3000,
+    "group_size": 128,
+    "history_conversations": 0,
+    "history_messages_per_conversation": 0,
+    "message_profile": "text"
+  },
+  "messages_received": 17064,
+  "messages_sent": 17064,
+  "send_failures": 0,
+  "queue_overflows": 0,
+  "history_syncs": 4,
+  "history_conversations": 0,
+  "history_messages": 0,
+  "duration_ms": 12987.802715,
+  "throughput_per_sec": 1313.8481061382522,
+  "send_latency": {
+    "min_ms": 0.377417,
+    "p50_ms": 12.071083,
+    "p95_ms": 21.876459,
+    "p99_ms": 26.280375,
+    "max_ms": 38.571083
+  },
+  "database": {
+    "calls": 120343,
+    "total_exec_ms": 1038.802042999996,
+    "rows": 136753,
+    "size_bytes": 84290707,
+    "queries": [
+      {
+        "query": "SELECT token, timestamp, sender_timestamp FROM whatsmeow_privacy_tokens WHERE our_jid=$1 AND (their_jid=$2 OR their_jid=( CASE WHEN $2 LIKE $3 THEN (SELECT pn || $4 FROM whatsmeow_lid_map WHERE lid=replace($2, $5, $6)) WHEN $2 LIKE $7 THEN (SELECT lid || $8 FROM whatsmeow_lid_map WHERE pn=replace($2, $9, $10)) ELSE $2 END )) ORDER BY timestamp DESC LIMIT $11",
+        "calls": 17128,
+        "total_exec_ms": 23.574294999999907,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 17069,
+        "total_exec_ms": 134.2533619999987,
+        "rows": 17069
+      },
+      {
+        "query": "SELECT session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 17069,
+        "total_exec_ms": 34.124638999999874,
+        "rows": 17004
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT $1, batch.their_id, batch.session FROM UNNEST($2::text[], $3::bytea[]) AS batch(their_id, session) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 17064,
+        "total_exec_ms": 586.2061900000006,
+        "rows": 34128
+      },
+      {
+        "query": "SELECT their_id, session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id = ANY($2)",
+        "calls": 17064,
+        "total_exec_ms": 161.25319299999938,
+        "rows": 34128
+      },
+      {
+        "query": "SELECT salt FROM whatsmeow_nct_salt WHERE our_jid=$1",
+        "calls": 17064,
+        "total_exec_ms": 25.38226999999944,
+        "rows": 17064
+      },
+      {
+        "query": "SELECT $3 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 17000,
+        "total_exec_ms": 66.79278699999826,
+        "rows": 17000
+      },
+      {
+        "query": "SELECT identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id=$2",
+        "calls": 203,
+        "total_exec_ms": 0.48727799999999943,
+        "rows": 139
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_sync_keys (jid, key_id, key_data, timestamp, fingerprint) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (jid, key_id) DO UPDATE SET key_data=excluded.key_data, timestamp=excluded.timestamp, fingerprint=excluded.fingerprint WHERE excluded.timestamp \u003e whatsmeow_app_state_sync_keys.timestamp",
+        "calls": 70,
+        "total_exec_ms": 1.924792,
+        "rows": 70
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT our_jid, replace(their_id, $2, $3), session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 65,
+        "total_exec_ms": 0.7519540000000002,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.531545,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) SELECT our_jid, replace(their_id, $2, $3), identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 65,
+        "total_exec_ms": 0.3812089999999999,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.21720899999999999,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sender_keys (our_jid, chat_id, sender_id, sender_key) SELECT our_jid, chat_id, replace(sender_id, $2, $3), sender_key FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2 || $4 ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key",
+        "calls": 65,
+        "total_exec_ms": 0.11633200000000003,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.08291300000000003,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 64,
+        "total_exec_ms": 1.1420329999999999,
+        "rows": 64
+      },
+      {
+        "query": "INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ($1, $2) ON CONFLICT (lid) DO UPDATE SET pn=excluded.pn WHERE whatsmeow_lid_map.pn\u003c\u003eexcluded.pn",
+        "calls": 64,
+        "total_exec_ms": 0.3372449999999999,
+        "rows": 64
+      },
+      {
+        "query": "DELETE FROM whatsmeow_lid_map WHERE (lid\u003c\u003e$1 AND pn=$2)",
+        "calls": 64,
+        "total_exec_ms": 0.20867000000000005,
+        "rows": 0
+      },
+      {
+        "query": "SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2",
+        "calls": 10,
+        "total_exec_ms": 0.09737500000000002,
+        "rows": 3
+      },
+      {
+        "query": "DELETE FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.038251,
+        "rows": 5
+      },
+      {
+        "query": "SELECT key_id, key FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.037541000000000005,
+        "rows": 5
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES ($1, $2, $3, $4, $5)",
+        "calls": 3,
+        "total_exec_ms": 0.5111680000000001,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_version (jid, name, version, hash) VALUES ($1, $2, $3, $4) ON CONFLICT (jid, name) DO UPDATE SET version=excluded.version, hash=excluded.hash",
+        "calls": 3,
+        "total_exec_ms": 0.194167,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_nct_salt (our_jid, salt) VALUES ($1, $2) ON CONFLICT (our_jid) DO UPDATE SET salt=excluded.salt",
+        "calls": 2,
+        "total_exec_ms": 0.10916700000000001,
+        "rows": 2
+      },
+      {
+        "query": "INSERT INTO whatsmeow_device (jid, lid, registration_id, noise_key, identity_key, signed_pre_key, signed_pre_key_id, signed_pre_key_sig, adv_key, adv_details, adv_account_sig, adv_account_sig_key, adv_device_sig, platform, business_name, push_name, facebook_uuid, lid_migration_ts) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) ON CONFLICT (jid) DO UPDATE SET lid=excluded.lid, platform=excluded.platform, business_name=e",
+        "calls": 1,
+        "total_exec_ms": 0.044208000000000004,
+        "rows": 1
+      },
+      {
+        "query": "SELECT key_data, timestamp, fingerprint FROM whatsmeow_app_state_sync_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 1,
+        "total_exec_ms": 0.0022500000000000003,
+        "rows": 1
+      }
+    ]
+  },
+  "runtime": {
+    "alloc_bytes": 8443904,
+    "heap_inuse_bytes": 10600448,
+    "sys_bytes": 27105544,
+    "total_alloc_bytes": 2273472304,
+    "num_gc": 494,
+    "goroutines": 74,
+    "peak_rss_bytes": 38739968,
+    "user_cpu_seconds": 5.684855,
+    "sys_cpu_seconds": 1.620517
+  },
+  "workload_runtime": {
+    "heap_alloc_bytes": 8443904,
+    "heap_inuse_bytes": 10600448,
+    "total_alloc_bytes": 2265498056,
+    "garbage_collections": 491,
+    "user_cpu_seconds": 5.643113,
+    "sys_cpu_seconds": 1.604015,
+    "peak_rss_bytes": 38739968
+  },
+  "session_runtime": {
+    "heap_alloc_bytes": 8443904,
+    "heap_inuse_bytes": 10600448,
+    "total_alloc_bytes": 2268676104,
+    "garbage_collections": 492,
+    "user_cpu_seconds": 5.651803,
+    "sys_cpu_seconds": 1.604963,
+    "peak_rss_bytes": 38739968
+  },
+  "resources": {
+    "network": {
+      "rx_bytes": 165290403,
+      "rx_packets": 231350,
+      "tx_bytes": 182476523,
+      "tx_packets": 224498
+    },
+    "process_io": {
+      "read_chars": 150116577,
+      "write_chars": 167752103,
+      "read_calls": 304272,
+      "write_calls": 183460,
+      "read_bytes": 0,
+      "write_bytes": 0
+    },
+    "block_io": {
+      "read_bytes": 0,
+      "write_bytes": 0,
+      "read_ops": 0,
+      "write_ops": 0
+    },
+    "temporary_files": {
+      "peak_bytes": 0,
+      "peak_files": 0,
+      "final_bytes": 0,
+      "final_files": 0
+    }
+  },
+  "message_types": {
+    "text": 17064
+  },
+  "media_uploads": 0,
+  "media_upload_bytes": 0,
+  "media_upload_latency": {
+    "min_ms": 0,
+    "p50_ms": 0,
+    "p95_ms": 0,
+    "p99_ms": 0,
+    "max_ms": 0
+  }
+}

--- a/benchmark/barback/results/maxrate-hypermeow-final-1800.json
+++ b/benchmark/barback/results/maxrate-hypermeow-final-1800.json
@@ -1,0 +1,268 @@
+{
+  "variant": "hypermeow-final",
+  "revision": "fc8c62034115b587bd5102834ee57ed1bdbda997",
+  "started_at": "2026-08-06T22:38:21.861562466Z",
+  "completed": true,
+  "target_messages": 18064,
+  "workload": {
+    "scenario": "ping-pong-1800",
+    "mode": "dm",
+    "rate": 1800,
+    "senders": 64,
+    "workers": 64,
+    "warmup_ms": 3000,
+    "group_size": 128,
+    "history_conversations": 0,
+    "history_messages_per_conversation": 0,
+    "message_profile": "text"
+  },
+  "messages_received": 18064,
+  "messages_sent": 18064,
+  "send_failures": 0,
+  "queue_overflows": 0,
+  "history_syncs": 4,
+  "history_conversations": 0,
+  "history_messages": 0,
+  "duration_ms": 13272.004325,
+  "throughput_per_sec": 1361.0604365139852,
+  "send_latency": {
+    "min_ms": 0.775917,
+    "p50_ms": 13.162708,
+    "p95_ms": 20.529334,
+    "p99_ms": 25.7085,
+    "max_ms": 40.80925
+  },
+  "database": {
+    "calls": 127334,
+    "total_exec_ms": 1105.9522719999982,
+    "rows": 144744,
+    "size_bytes": 87870611,
+    "queries": [
+      {
+        "query": "SELECT token, timestamp, sender_timestamp FROM whatsmeow_privacy_tokens WHERE our_jid=$1 AND (their_jid=$2 OR their_jid=( CASE WHEN $2 LIKE $3 THEN (SELECT pn || $4 FROM whatsmeow_lid_map WHERE lid=replace($2, $5, $6)) WHEN $2 LIKE $7 THEN (SELECT lid || $8 FROM whatsmeow_lid_map WHERE pn=replace($2, $9, $10)) ELSE $2 END )) ORDER BY timestamp DESC LIMIT $11",
+        "calls": 18128,
+        "total_exec_ms": 23.969687000001404,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 18069,
+        "total_exec_ms": 135.87279699999854,
+        "rows": 18069
+      },
+      {
+        "query": "SELECT session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 18069,
+        "total_exec_ms": 36.35444899999903,
+        "rows": 18004
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT $1, batch.their_id, batch.session FROM UNNEST($2::text[], $3::bytea[]) AS batch(their_id, session) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 18064,
+        "total_exec_ms": 635.3807010000003,
+        "rows": 36128
+      },
+      {
+        "query": "SELECT their_id, session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id = ANY($2)",
+        "calls": 18064,
+        "total_exec_ms": 172.57624100000012,
+        "rows": 36128
+      },
+      {
+        "query": "SELECT salt FROM whatsmeow_nct_salt WHERE our_jid=$1",
+        "calls": 18064,
+        "total_exec_ms": 26.39978700000042,
+        "rows": 18064
+      },
+      {
+        "query": "SELECT $3 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 18000,
+        "total_exec_ms": 69.0907859999984,
+        "rows": 18000
+      },
+      {
+        "query": "SELECT identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id=$2",
+        "calls": 194,
+        "total_exec_ms": 0.43616699999999964,
+        "rows": 130
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_sync_keys (jid, key_id, key_data, timestamp, fingerprint) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (jid, key_id) DO UPDATE SET key_data=excluded.key_data, timestamp=excluded.timestamp, fingerprint=excluded.fingerprint WHERE excluded.timestamp \u003e whatsmeow_app_state_sync_keys.timestamp",
+        "calls": 70,
+        "total_exec_ms": 1.1387020000000003,
+        "rows": 70
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT our_jid, replace(their_id, $2, $3), session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 65,
+        "total_exec_ms": 0.820329,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.44228400000000007,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) SELECT our_jid, replace(their_id, $2, $3), identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 65,
+        "total_exec_ms": 0.36850900000000003,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.31154200000000004,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sender_keys (our_jid, chat_id, sender_id, sender_key) SELECT our_jid, chat_id, replace(sender_id, $2, $3), sender_key FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2 || $4 ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key",
+        "calls": 65,
+        "total_exec_ms": 0.11933500000000004,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.06175200000000004,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 64,
+        "total_exec_ms": 1.2219970000000004,
+        "rows": 64
+      },
+      {
+        "query": "INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ($1, $2) ON CONFLICT (lid) DO UPDATE SET pn=excluded.pn WHERE whatsmeow_lid_map.pn\u003c\u003eexcluded.pn",
+        "calls": 64,
+        "total_exec_ms": 0.3426589999999998,
+        "rows": 64
+      },
+      {
+        "query": "DELETE FROM whatsmeow_lid_map WHERE (lid\u003c\u003e$1 AND pn=$2)",
+        "calls": 64,
+        "total_exec_ms": 0.12725200000000006,
+        "rows": 0
+      },
+      {
+        "query": "SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2",
+        "calls": 10,
+        "total_exec_ms": 0.058832999999999996,
+        "rows": 3
+      },
+      {
+        "query": "DELETE FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.044209,
+        "rows": 5
+      },
+      {
+        "query": "SELECT key_id, key FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.042376,
+        "rows": 5
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES ($1, $2, $3, $4, $5)",
+        "calls": 3,
+        "total_exec_ms": 0.346292,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_version (jid, name, version, hash) VALUES ($1, $2, $3, $4) ON CONFLICT (jid, name) DO UPDATE SET version=excluded.version, hash=excluded.hash",
+        "calls": 3,
+        "total_exec_ms": 0.257042,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_nct_salt (our_jid, salt) VALUES ($1, $2) ON CONFLICT (our_jid) DO UPDATE SET salt=excluded.salt",
+        "calls": 2,
+        "total_exec_ms": 0.10850099999999999,
+        "rows": 2
+      },
+      {
+        "query": "INSERT INTO whatsmeow_device (jid, lid, registration_id, noise_key, identity_key, signed_pre_key, signed_pre_key_id, signed_pre_key_sig, adv_key, adv_details, adv_account_sig, adv_account_sig_key, adv_device_sig, platform, business_name, push_name, facebook_uuid, lid_migration_ts) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) ON CONFLICT (jid) DO UPDATE SET lid=excluded.lid, platform=excluded.platform, business_name=e",
+        "calls": 1,
+        "total_exec_ms": 0.053251,
+        "rows": 1
+      },
+      {
+        "query": "SELECT key_data, timestamp, fingerprint FROM whatsmeow_app_state_sync_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 1,
+        "total_exec_ms": 0.006792,
+        "rows": 1
+      }
+    ]
+  },
+  "runtime": {
+    "alloc_bytes": 9871344,
+    "heap_inuse_bytes": 12189696,
+    "sys_bytes": 27699480,
+    "total_alloc_bytes": 2398154736,
+    "num_gc": 452,
+    "goroutines": 74,
+    "peak_rss_bytes": 40529920,
+    "user_cpu_seconds": 5.782937,
+    "sys_cpu_seconds": 1.749868
+  },
+  "workload_runtime": {
+    "heap_alloc_bytes": 9871344,
+    "heap_inuse_bytes": 12189696,
+    "total_alloc_bytes": 2390215472,
+    "garbage_collections": 449,
+    "user_cpu_seconds": 5.74256,
+    "sys_cpu_seconds": 1.728418,
+    "peak_rss_bytes": 40529920
+  },
+  "session_runtime": {
+    "heap_alloc_bytes": 9871344,
+    "heap_inuse_bytes": 12189696,
+    "total_alloc_bytes": 2393395032,
+    "garbage_collections": 450,
+    "user_cpu_seconds": 5.750742000000001,
+    "sys_cpu_seconds": 1.730551,
+    "peak_rss_bytes": 40529920
+  },
+  "resources": {
+    "network": {
+      "rx_bytes": 175102903,
+      "rx_packets": 244938,
+      "tx_bytes": 193250337,
+      "tx_packets": 237334
+    },
+    "process_io": {
+      "read_chars": 159035441,
+      "write_chars": 177681911,
+      "read_calls": 319414,
+      "write_calls": 193831,
+      "read_bytes": 0,
+      "write_bytes": 0
+    },
+    "block_io": {
+      "read_bytes": 0,
+      "write_bytes": 0,
+      "read_ops": 0,
+      "write_ops": 0
+    },
+    "temporary_files": {
+      "peak_bytes": 0,
+      "peak_files": 0,
+      "final_bytes": 0,
+      "final_files": 0
+    }
+  },
+  "message_types": {
+    "text": 18064
+  },
+  "media_uploads": 0,
+  "media_upload_bytes": 0,
+  "media_upload_latency": {
+    "min_ms": 0,
+    "p50_ms": 0,
+    "p95_ms": 0,
+    "p99_ms": 0,
+    "max_ms": 0
+  }
+}

--- a/benchmark/barback/results/maxrate-ping-pong.md
+++ b/benchmark/barback/results/maxrate-ping-pong.md
@@ -1,0 +1,42 @@
+# Ping-pong saturation comparison
+
+Measured on 2026-08-07 with the Compose stack capped at 2 vCPU and 3.5 GB of service memory. Each run used a fresh PostgreSQL volume and device, 64 DM senders, 64 chat-affine workers, a 3-second Signal-session warmup, and a 10-second text-message flood. TLS, Noise verification, Signal encryption/decryption, PostgreSQL persistence, server acknowledgements, and Barback pong decryption remained enabled.
+
+Revisions:
+
+- HyperMeow: `fc8c62034115b587bd5102834ee57ed1bdbda997`
+- WhatsMeow: `39b719baa629e9cfaee5e095459c12e4df1eb5e4`
+
+The upstream tree received only the benchmark socket URL, Origin, and Noise certificate-authority injection required to connect to Barback.
+
+## Highest healthy rate
+
+Healthy means the client completed every send without failure or queue overflow, Barback completed the session, the post-warmup flood stayed at the configured rate, and average wire pong RTT remained below 100 ms.
+
+| Metric | HyperMeow | WhatsMeow |
+| --- | ---: | ---: |
+| Offered ping-pong pairs/s | 1,700 | 900 |
+| Actual flood pairs/s | 1,699.82 | 900.27 |
+| Successfully decrypted pongs | 17,062 / 17,064 | 9,063 / 9,064 |
+| Successful pairs/s | 1,699.62 | 900.17 |
+| Total ping + pong messages/s | 3,399.24 | 1,800.34 |
+| Average wire pong RTT | 28.84 ms | 36.92 ms |
+| Maximum wire pong RTT | 106.43 ms | 114.12 ms |
+| Client send p99 | 26.28 ms | 30.58 ms |
+| Client send failures | 0 | 0 |
+| Client queue overflows | 0 | 0 |
+| Peak client RSS | 38,739,968 B | 38,162,432 B |
+| PostgreSQL calls | 120,343 | 127,534 |
+
+HyperMeow sustained 1.888 times the successful ping-pong rate. Both runs had a negligible first-chain Signal setup failure rate (`counter 0` after the warmup): 2 pongs for HyperMeow and 1 for WhatsMeow. No live client send failed, and no message was lost on the wire.
+
+## Saturation boundary
+
+At 1,800 offered pairs/s, HyperMeow completed every client send and delivered 1,750.84 flood pairs/s, but average wire pong RTT rose to 270.16 ms. At 1,000 offered pairs/s, WhatsMeow completed every client send, but Barback still had one unresolved pong when the client settlement window ended. These are saturation points, not recommended operating rates.
+
+The retained JSON reports are:
+
+- `maxrate-hypermeow-final-1700.json`
+- `maxrate-hypermeow-final-1800.json`
+- `maxrate-whatsmeow-final-900.json`
+- `maxrate-whatsmeow-final-1000.json`

--- a/benchmark/barback/results/maxrate-whatsmeow-final-1000.json
+++ b/benchmark/barback/results/maxrate-whatsmeow-final-1000.json
@@ -1,0 +1,262 @@
+{
+  "variant": "whatsmeow-final",
+  "revision": "39b719baa629e9cfaee5e095459c12e4df1eb5e4",
+  "started_at": "2026-08-06T22:41:39.220247043Z",
+  "completed": true,
+  "target_messages": 10064,
+  "workload": {
+    "scenario": "ping-pong-1000",
+    "mode": "dm",
+    "rate": 1000,
+    "senders": 64,
+    "workers": 64,
+    "warmup_ms": 3000,
+    "group_size": 128,
+    "history_conversations": 0,
+    "history_messages_per_conversation": 0,
+    "message_profile": "text"
+  },
+  "messages_received": 10064,
+  "messages_sent": 10064,
+  "send_failures": 0,
+  "queue_overflows": 0,
+  "history_syncs": 4,
+  "history_conversations": 0,
+  "history_messages": 0,
+  "duration_ms": 13057.300548,
+  "throughput_per_sec": 770.7565559208571,
+  "send_latency": {
+    "min_ms": 0.61125,
+    "p50_ms": 18.856791,
+    "p95_ms": 30.3215,
+    "p99_ms": 36.272542,
+    "max_ms": 52.854458
+  },
+  "database": {
+    "calls": 141534,
+    "total_exec_ms": 961.0092119999939,
+    "rows": 140880,
+    "size_bytes": 52636819,
+    "queries": [
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 30197,
+        "total_exec_ms": 446.59455199999843,
+        "rows": 30197
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 30197,
+        "total_exec_ms": 200.83785499999806,
+        "rows": 30197
+      },
+      {
+        "query": "SELECT identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id=$2",
+        "calls": 30197,
+        "total_exec_ms": 107.51130499999677,
+        "rows": 30133
+      },
+      {
+        "query": "SELECT token, timestamp, sender_timestamp FROM whatsmeow_privacy_tokens WHERE our_jid=$1 AND (their_jid=$2 OR their_jid=( CASE WHEN $2 LIKE $3 THEN (SELECT pn || $4 FROM whatsmeow_lid_map WHERE lid=replace($2, $5, $6)) WHEN $2 LIKE $7 THEN (SELECT lid || $8 FROM whatsmeow_lid_map WHERE pn=replace($2, $9, $10)) ELSE $2 END )) ORDER BY timestamp DESC LIMIT $11",
+        "calls": 10128,
+        "total_exec_ms": 15.800454000000265,
+        "rows": 0
+      },
+      {
+        "query": "SELECT session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 10069,
+        "total_exec_ms": 21.763450000000525,
+        "rows": 10004
+      },
+      {
+        "query": "SELECT their_id, session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id IN ($2,$3)",
+        "calls": 10064,
+        "total_exec_ms": 102.93547000000063,
+        "rows": 20128
+      },
+      {
+        "query": "SELECT salt FROM whatsmeow_nct_salt WHERE our_jid=$1",
+        "calls": 10064,
+        "total_exec_ms": 18.10349799999968,
+        "rows": 10064
+      },
+      {
+        "query": "SELECT $3 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 10000,
+        "total_exec_ms": 42.6434129999995,
+        "rows": 10000
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_sync_keys (jid, key_id, key_data, timestamp, fingerprint) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (jid, key_id) DO UPDATE SET key_data=excluded.key_data, timestamp=excluded.timestamp, fingerprint=excluded.fingerprint WHERE excluded.timestamp \u003e whatsmeow_app_state_sync_keys.timestamp",
+        "calls": 70,
+        "total_exec_ms": 1.1492090000000001,
+        "rows": 70
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT our_jid, replace(their_id, $2, $3), session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 65,
+        "total_exec_ms": 0.8237920000000001,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) SELECT our_jid, replace(their_id, $2, $3), identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 65,
+        "total_exec_ms": 0.399213,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.376665,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.25212199999999996,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sender_keys (our_jid, chat_id, sender_id, sender_key) SELECT our_jid, chat_id, replace(sender_id, $2, $3), sender_key FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2 || $4 ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key",
+        "calls": 65,
+        "total_exec_ms": 0.12283900000000006,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.07596200000000003,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ($1, $2) ON CONFLICT (lid) DO UPDATE SET pn=excluded.pn WHERE whatsmeow_lid_map.pn\u003c\u003eexcluded.pn",
+        "calls": 64,
+        "total_exec_ms": 0.5254649999999998,
+        "rows": 64
+      },
+      {
+        "query": "DELETE FROM whatsmeow_lid_map WHERE (lid\u003c\u003e$1 AND pn=$2)",
+        "calls": 64,
+        "total_exec_ms": 0.17136899999999994,
+        "rows": 0
+      },
+      {
+        "query": "SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2",
+        "calls": 10,
+        "total_exec_ms": 0.065581,
+        "rows": 3
+      },
+      {
+        "query": "SELECT key_id, key FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.054166000000000006,
+        "rows": 5
+      },
+      {
+        "query": "DELETE FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.02825,
+        "rows": 5
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES ($1, $2, $3, $4, $5)",
+        "calls": 3,
+        "total_exec_ms": 0.278957,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_version (jid, name, version, hash) VALUES ($1, $2, $3, $4) ON CONFLICT (jid, name) DO UPDATE SET version=excluded.version, hash=excluded.hash",
+        "calls": 3,
+        "total_exec_ms": 0.13933299999999998,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_nct_salt (our_jid, salt) VALUES ($1, $2) ON CONFLICT (our_jid) DO UPDATE SET salt=excluded.salt",
+        "calls": 2,
+        "total_exec_ms": 0.304958,
+        "rows": 2
+      },
+      {
+        "query": "INSERT INTO whatsmeow_device (jid, lid, registration_id, noise_key, identity_key, signed_pre_key, signed_pre_key_id, signed_pre_key_sig, adv_key, adv_details, adv_account_sig, adv_account_sig_key, adv_device_sig, platform, business_name, push_name, facebook_uuid, lid_migration_ts, companion_meta_nonce) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) ON CONFLICT (jid) DO UPDATE SET lid=excluded.lid, platform=excluded.pl",
+        "calls": 1,
+        "total_exec_ms": 0.048708999999999995,
+        "rows": 1
+      },
+      {
+        "query": "SELECT key_data, timestamp, fingerprint FROM whatsmeow_app_state_sync_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 1,
+        "total_exec_ms": 0.0026249999999999997,
+        "rows": 1
+      }
+    ]
+  },
+  "runtime": {
+    "alloc_bytes": 7869096,
+    "heap_inuse_bytes": 10821632,
+    "sys_bytes": 23173384,
+    "total_alloc_bytes": 1444618896,
+    "num_gc": 299,
+    "goroutines": 74,
+    "peak_rss_bytes": 38580224,
+    "user_cpu_seconds": 4.352235,
+    "sys_cpu_seconds": 1.964008
+  },
+  "workload_runtime": {
+    "heap_alloc_bytes": 7869096,
+    "heap_inuse_bytes": 10821632,
+    "total_alloc_bytes": 1436580440,
+    "garbage_collections": 296,
+    "user_cpu_seconds": 4.3105530000000005,
+    "sys_cpu_seconds": 1.948652,
+    "peak_rss_bytes": 38580224
+  },
+  "session_runtime": {
+    "heap_alloc_bytes": 7869096,
+    "heap_inuse_bytes": 10821632,
+    "total_alloc_bytes": 1439775432,
+    "garbage_collections": 297,
+    "user_cpu_seconds": 4.319317,
+    "sys_cpu_seconds": 1.9499009999999999,
+    "peak_rss_bytes": 38580224
+  },
+  "resources": {
+    "network": {
+      "rx_bytes": 107626327,
+      "rx_packets": 237959,
+      "tx_bytes": 124523342,
+      "tx_packets": 223294
+    },
+    "process_io": {
+      "read_chars": 92079911,
+      "write_chars": 109940704,
+      "read_calls": 358447,
+      "write_calls": 211751,
+      "read_bytes": 0,
+      "write_bytes": 0
+    },
+    "block_io": {
+      "read_bytes": 0,
+      "write_bytes": 0,
+      "read_ops": 0,
+      "write_ops": 0
+    },
+    "temporary_files": {
+      "peak_bytes": 0,
+      "peak_files": 0,
+      "final_bytes": 0,
+      "final_files": 0
+    }
+  },
+  "message_types": {
+    "text": 10064
+  },
+  "media_uploads": 0,
+  "media_upload_bytes": 0,
+  "media_upload_latency": {
+    "min_ms": 0,
+    "p50_ms": 0,
+    "p95_ms": 0,
+    "p99_ms": 0,
+    "max_ms": 0
+  }
+}

--- a/benchmark/barback/results/maxrate-whatsmeow-final-900.json
+++ b/benchmark/barback/results/maxrate-whatsmeow-final-900.json
@@ -1,0 +1,262 @@
+{
+  "variant": "whatsmeow-final",
+  "revision": "39b719baa629e9cfaee5e095459c12e4df1eb5e4",
+  "started_at": "2026-08-06T22:43:08.692507126Z",
+  "completed": true,
+  "target_messages": 9064,
+  "workload": {
+    "scenario": "ping-pong-900",
+    "mode": "dm",
+    "rate": 900,
+    "senders": 64,
+    "workers": 64,
+    "warmup_ms": 3000,
+    "group_size": 128,
+    "history_conversations": 0,
+    "history_messages_per_conversation": 0,
+    "message_profile": "text"
+  },
+  "messages_received": 9064,
+  "messages_sent": 9064,
+  "send_failures": 0,
+  "queue_overflows": 0,
+  "history_syncs": 4,
+  "history_conversations": 0,
+  "history_messages": 0,
+  "duration_ms": 12979.446548,
+  "throughput_per_sec": 698.3348609264599,
+  "send_latency": {
+    "min_ms": 0.778,
+    "p50_ms": 15.837291,
+    "p95_ms": 25.291125,
+    "p99_ms": 30.583209,
+    "max_ms": 39.208833
+  },
+  "database": {
+    "calls": 127534,
+    "total_exec_ms": 844.9589409999935,
+    "rows": 126880,
+    "size_bytes": 49015955,
+    "queries": [
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 27197,
+        "total_exec_ms": 392.63854099999776,
+        "rows": 27197
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 27197,
+        "total_exec_ms": 176.47354199999805,
+        "rows": 27197
+      },
+      {
+        "query": "SELECT identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id=$2",
+        "calls": 27197,
+        "total_exec_ms": 93.63712499999676,
+        "rows": 27133
+      },
+      {
+        "query": "SELECT token, timestamp, sender_timestamp FROM whatsmeow_privacy_tokens WHERE our_jid=$1 AND (their_jid=$2 OR their_jid=( CASE WHEN $2 LIKE $3 THEN (SELECT pn || $4 FROM whatsmeow_lid_map WHERE lid=replace($2, $5, $6)) WHEN $2 LIKE $7 THEN (SELECT lid || $8 FROM whatsmeow_lid_map WHERE pn=replace($2, $9, $10)) ELSE $2 END )) ORDER BY timestamp DESC LIMIT $11",
+        "calls": 9128,
+        "total_exec_ms": 13.157601000000131,
+        "rows": 0
+      },
+      {
+        "query": "SELECT session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 9069,
+        "total_exec_ms": 19.888993000000355,
+        "rows": 9004
+      },
+      {
+        "query": "SELECT their_id, session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id IN ($2,$3)",
+        "calls": 9064,
+        "total_exec_ms": 90.79611900000039,
+        "rows": 18128
+      },
+      {
+        "query": "SELECT salt FROM whatsmeow_nct_salt WHERE our_jid=$1",
+        "calls": 9064,
+        "total_exec_ms": 14.947356000000257,
+        "rows": 9064
+      },
+      {
+        "query": "SELECT $3 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+        "calls": 9000,
+        "total_exec_ms": 38.95320799999951,
+        "rows": 9000
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_sync_keys (jid, key_id, key_data, timestamp, fingerprint) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (jid, key_id) DO UPDATE SET key_data=excluded.key_data, timestamp=excluded.timestamp, fingerprint=excluded.fingerprint WHERE excluded.timestamp \u003e whatsmeow_app_state_sync_keys.timestamp",
+        "calls": 70,
+        "total_exec_ms": 1.2831279999999998,
+        "rows": 70
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) SELECT our_jid, replace(their_id, $2, $3), session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+        "calls": 65,
+        "total_exec_ms": 0.6053750000000002,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.45666099999999993,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_identity_keys (our_jid, their_id, identity) SELECT our_jid, replace(their_id, $2, $3), identity FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2 || $4 ON CONFLICT (our_jid, their_id) DO UPDATE SET identity=excluded.identity",
+        "calls": 65,
+        "total_exec_ms": 0.318834,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.21604500000000004,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_sender_keys (our_jid, chat_id, sender_id, sender_key) SELECT our_jid, chat_id, replace(sender_id, $2, $3), sender_key FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2 || $4 ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key",
+        "calls": 65,
+        "total_exec_ms": 0.11008300000000004,
+        "rows": 0
+      },
+      {
+        "query": "DELETE FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2",
+        "calls": 65,
+        "total_exec_ms": 0.06087000000000003,
+        "rows": 0
+      },
+      {
+        "query": "INSERT INTO whatsmeow_lid_map (lid, pn) VALUES ($1, $2) ON CONFLICT (lid) DO UPDATE SET pn=excluded.pn WHERE whatsmeow_lid_map.pn\u003c\u003eexcluded.pn",
+        "calls": 64,
+        "total_exec_ms": 0.523085,
+        "rows": 64
+      },
+      {
+        "query": "DELETE FROM whatsmeow_lid_map WHERE (lid\u003c\u003e$1 AND pn=$2)",
+        "calls": 64,
+        "total_exec_ms": 0.13012500000000005,
+        "rows": 0
+      },
+      {
+        "query": "SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2",
+        "calls": 10,
+        "total_exec_ms": 0.031291,
+        "rows": 3
+      },
+      {
+        "query": "DELETE FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.102959,
+        "rows": 5
+      },
+      {
+        "query": "SELECT key_id, key FROM whatsmeow_pre_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 5,
+        "total_exec_ms": 0.038458,
+        "rows": 5
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_version (jid, name, version, hash) VALUES ($1, $2, $3, $4) ON CONFLICT (jid, name) DO UPDATE SET version=excluded.version, hash=excluded.hash",
+        "calls": 3,
+        "total_exec_ms": 0.23233399999999998,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES ($1, $2, $3, $4, $5)",
+        "calls": 3,
+        "total_exec_ms": 0.197292,
+        "rows": 3
+      },
+      {
+        "query": "INSERT INTO whatsmeow_nct_salt (our_jid, salt) VALUES ($1, $2) ON CONFLICT (our_jid) DO UPDATE SET salt=excluded.salt",
+        "calls": 2,
+        "total_exec_ms": 0.112084,
+        "rows": 2
+      },
+      {
+        "query": "INSERT INTO whatsmeow_device (jid, lid, registration_id, noise_key, identity_key, signed_pre_key, signed_pre_key_id, signed_pre_key_sig, adv_key, adv_details, adv_account_sig, adv_account_sig_key, adv_device_sig, platform, business_name, push_name, facebook_uuid, lid_migration_ts, companion_meta_nonce) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) ON CONFLICT (jid) DO UPDATE SET lid=excluded.lid, platform=excluded.pl",
+        "calls": 1,
+        "total_exec_ms": 0.045124,
+        "rows": 1
+      },
+      {
+        "query": "SELECT key_data, timestamp, fingerprint FROM whatsmeow_app_state_sync_keys WHERE jid=$1 AND key_id=$2",
+        "calls": 1,
+        "total_exec_ms": 0.0027080000000000003,
+        "rows": 1
+      }
+    ]
+  },
+  "runtime": {
+    "alloc_bytes": 9356672,
+    "heap_inuse_bytes": 11444224,
+    "sys_bytes": 27105544,
+    "total_alloc_bytes": 1304822832,
+    "num_gc": 273,
+    "goroutines": 74,
+    "peak_rss_bytes": 38162432,
+    "user_cpu_seconds": 4.00036,
+    "sys_cpu_seconds": 1.822895
+  },
+  "workload_runtime": {
+    "heap_alloc_bytes": 9356672,
+    "heap_inuse_bytes": 11444224,
+    "total_alloc_bytes": 1296761616,
+    "garbage_collections": 270,
+    "user_cpu_seconds": 3.9597909999999996,
+    "sys_cpu_seconds": 1.8001369999999999,
+    "peak_rss_bytes": 38162432
+  },
+  "session_runtime": {
+    "heap_alloc_bytes": 9356672,
+    "heap_inuse_bytes": 11444224,
+    "total_alloc_bytes": 1300010752,
+    "garbage_collections": 271,
+    "user_cpu_seconds": 3.9656909999999996,
+    "sys_cpu_seconds": 1.8050659999999998,
+    "peak_rss_bytes": 38162432
+  },
+  "resources": {
+    "network": {
+      "rx_bytes": 96867534,
+      "rx_packets": 214402,
+      "tx_bytes": 112146752,
+      "tx_packets": 202015
+    },
+    "process_io": {
+      "read_chars": 82873797,
+      "write_chars": 98967748,
+      "read_calls": 329820,
+      "write_calls": 192437,
+      "read_bytes": 0,
+      "write_bytes": 0
+    },
+    "block_io": {
+      "read_bytes": 0,
+      "write_bytes": 0,
+      "read_ops": 0,
+      "write_ops": 0
+    },
+    "temporary_files": {
+      "peak_bytes": 0,
+      "peak_files": 0,
+      "final_bytes": 0,
+      "final_files": 0
+    }
+  },
+  "message_types": {
+    "text": 9064
+  },
+  "media_uploads": 0,
+  "media_upload_bytes": 0,
+  "media_upload_latency": {
+    "min_ms": 0,
+    "p50_ms": 0,
+    "p95_ms": 0,
+    "p99_ms": 0,
+    "max_ms": 0
+  }
+}


### PR DESCRIPTION
## Summary

- preserve per-chat ordering while parallelizing the benchmark workload
- record bounded ping-pong saturation runs for HyperMeow and upstream WhatsMeow
- document the healthy and saturated rate boundaries

## Verification

- `go test ./...`
- `go test -race ./...` in `benchmark/barback`
- `go vet ./...` in `benchmark/barback`
- `gofmt -d` and `git diff --check`