### PR TITLE
Fix privacy cache completeness

### DIFF
--- a/privacysettings.go
+++ b/privacysettings.go
@@ -84,6 +84,12 @@ func (cli *Client) SetPrivacySetting(ctx context.Context, name types.PrivacySett
 		return settings, err
 	}
 	settings = *settingsPtr
+	applyPrivacySetting(&settings, name, value)
+	cli.privacySettingsCache.Store(&settings)
+	return
+}
+
+func applyPrivacySetting(settings *types.PrivacySettings, name types.PrivacySettingType, value types.PrivacySetting) {
 	switch name {
 	case types.PrivacySettingTypeGroupAdd:
 		settings.GroupAdd = value
@@ -99,9 +105,13 @@ func (cli *Client) SetPrivacySetting(ctx context.Context, name types.PrivacySett
 		settings.Online = value
 	case types.PrivacySettingTypeCallAdd:
 		settings.CallAdd = value
+	case types.PrivacySettingTypeMessages:
+		settings.Messages = value
+	case types.PrivacySettingTypeDefense:
+		settings.Defense = value
+	case types.PrivacySettingTypeStickers:
+		settings.Stickers = value
 	}
-	cli.privacySettingsCache.Store(&settings)
-	return
 }
 
 // SetDefaultDisappearingTimer will set the default disappearing message timer.

--- a/privacysettings_test.go
+++ b/privacysettings_test.go
@@ -1,0 +1,36 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestApplyPrivacySettingUpdatesEveryCategory(t *testing.T) {
+	tests := []struct {
+		name  types.PrivacySettingType
+		value types.PrivacySetting
+		get   func(types.PrivacySettings) types.PrivacySetting
+	}{
+		{types.PrivacySettingTypeGroupAdd, types.PrivacySettingContacts, func(s types.PrivacySettings) types.PrivacySetting { return s.GroupAdd }},
+		{types.PrivacySettingTypeLastSeen, types.PrivacySettingContacts, func(s types.PrivacySettings) types.PrivacySetting { return s.LastSeen }},
+		{types.PrivacySettingTypeStatus, types.PrivacySettingContacts, func(s types.PrivacySettings) types.PrivacySetting { return s.Status }},
+		{types.PrivacySettingTypeProfile, types.PrivacySettingContacts, func(s types.PrivacySettings) types.PrivacySetting { return s.Profile }},
+		{types.PrivacySettingTypeReadReceipts, types.PrivacySettingNone, func(s types.PrivacySettings) types.PrivacySetting { return s.ReadReceipts }},
+		{types.PrivacySettingTypeOnline, types.PrivacySettingMatchLastSeen, func(s types.PrivacySettings) types.PrivacySetting { return s.Online }},
+		{types.PrivacySettingTypeCallAdd, types.PrivacySettingKnown, func(s types.PrivacySettings) types.PrivacySetting { return s.CallAdd }},
+		{types.PrivacySettingTypeMessages, types.PrivacySettingContacts, func(s types.PrivacySettings) types.PrivacySetting { return s.Messages }},
+		{types.PrivacySettingTypeDefense, types.PrivacySettingOnStandard, func(s types.PrivacySettings) types.PrivacySetting { return s.Defense }},
+		{types.PrivacySettingTypeStickers, types.PrivacySettingContactAllowlist, func(s types.PrivacySettings) types.PrivacySetting { return s.Stickers }},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.name), func(t *testing.T) {
+			var settings types.PrivacySettings
+			applyPrivacySetting(&settings, test.name, test.value)
+			if actual := test.get(settings); actual != test.value {
+				t.Fatalf("setting = %q, want %q", actual, test.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Update the cached and returned privacy settings for the newer `messages`, `defense`, and `stickers` categories after a successful settings change. A table-driven test covers all supported privacy categories.

## Why

The network operation succeeded for these categories, but the local cache and returned `PrivacySettings` value retained stale fields. API clients could therefore observe the old value immediately after a successful update.

## Validation

- `go test ./...`
- Titan authenticated HTTP-to-Barback E2E suite using this commit
