### PR TITLE
Add phone number consent message builders

### DIFF
--- a/phone_number_message.go
+++ b/phone_number_message.go
@@ -1,0 +1,18 @@
+package whatsmeow
+
+import "go.mau.fi/whatsmeow/proto/waE2E"
+
+func BuildRequestPhoneNumberMessage(contextInfo *waE2E.ContextInfo) *waE2E.Message {
+	return &waE2E.Message{
+		RequestPhoneNumberMessage: &waE2E.RequestPhoneNumberMessage{
+			ContextInfo: contextInfo,
+		},
+	}
+}
+
+func BuildSharePhoneNumberMessage() *waE2E.Message {
+	messageType := waE2E.ProtocolMessage_SHARE_PHONE_NUMBER
+	return &waE2E.Message{
+		ProtocolMessage: &waE2E.ProtocolMessage{Type: &messageType},
+	}
+}

--- a/phone_number_message_test.go
+++ b/phone_number_message_test.go
@@ -1,0 +1,35 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+func TestBuildRequestPhoneNumberMessage(t *testing.T) {
+	contextInfo := &waE2E.ContextInfo{StanzaID: stringPtr("request-id")}
+	message := BuildRequestPhoneNumberMessage(contextInfo)
+
+	request := message.GetRequestPhoneNumberMessage()
+	if request == nil {
+		t.Fatal("expected request phone number message")
+	}
+	if request.GetContextInfo().GetStanzaID() != "request-id" {
+		t.Fatalf("unexpected context info: %+v", request.GetContextInfo())
+	}
+}
+
+func TestBuildSharePhoneNumberMessage(t *testing.T) {
+	message := BuildSharePhoneNumberMessage()
+	protocolMessage := message.GetProtocolMessage()
+	if protocolMessage == nil {
+		t.Fatal("expected protocol message")
+	}
+	if protocolMessage.GetType() != waE2E.ProtocolMessage_SHARE_PHONE_NUMBER {
+		t.Fatalf("unexpected protocol message type: %s", protocolMessage.GetType())
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## What

Adds protocol builders for requesting a hidden phone number and voluntarily sharing a phone number in response.

## Why

LID is the stable user identifier, while phone numbers may be unavailable. Callers need an explicit consent flow instead of treating a phone number as identity or attempting to infer one.

## Impact

This layer only constructs the protocol messages. It does not request or disclose phone numbers automatically.

## Checks

- `go test ./...`
- `go vet ./...`

