### PR TITLE
Use LIDs as Signal identities and support usernames

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -329,6 +329,7 @@ func (cli *Client) dispatchAppState(ctx context.Context, name appstate.WAPatchNa
 		}
 	case appstate.IndexLIDContact:
 		act := mutation.Action.GetLidContactAction()
+		eventToDispatch = &events.LIDContact{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		if cli.Store.Contacts != nil {
 			storeUpdateError = cli.Store.Contacts.PutContactName(ctx, jid, act.GetFirstName(), act.GetFullName())
 			if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && storeUpdateError == nil {

--- a/appstate.go
+++ b/appstate.go
@@ -227,19 +227,21 @@ func (cli *Client) filterContacts(mutations []appstate.Mutation) ([]appstate.Mut
 			jid, _ := types.ParseJID(mutation.Index[1])
 			act := mutation.Action.GetContactAction()
 			contacts = append(contacts, store.ContactEntry{
-				JID:       jid,
-				FirstName: act.GetFirstName(),
-				FullName:  act.GetFullName(),
-				Username:  act.GetUsername(),
+				JID:         jid,
+				FirstName:   act.GetFirstName(),
+				FullName:    act.GetFullName(),
+				Username:    act.GetUsername(),
+				UsernameSet: true,
 			})
 		} else if len(mutation.Index) > 1 && mutation.Index[0] == appstate.IndexLIDContact {
 			jid, _ := types.ParseJID(mutation.Index[1])
 			act := mutation.Action.GetLidContactAction()
 			contacts = append(contacts, store.ContactEntry{
-				JID:       jid,
-				FirstName: act.GetFirstName(),
-				FullName:  act.GetFullName(),
-				Username:  act.GetUsername(),
+				JID:         jid,
+				FirstName:   act.GetFirstName(),
+				FullName:    act.GetFullName(),
+				Username:    act.GetUsername(),
+				UsernameSet: true,
 			})
 		} else {
 			filteredMutations = append(filteredMutations, mutation)

--- a/appstate.go
+++ b/appstate.go
@@ -230,6 +230,7 @@ func (cli *Client) filterContacts(mutations []appstate.Mutation) ([]appstate.Mut
 				JID:       jid,
 				FirstName: act.GetFirstName(),
 				FullName:  act.GetFullName(),
+				Username:  act.GetUsername(),
 			})
 		} else {
 			filteredMutations = append(filteredMutations, mutation)
@@ -313,6 +314,9 @@ func (cli *Client) dispatchAppState(ctx context.Context, name appstate.WAPatchNa
 		eventToDispatch = &events.Contact{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		if cli.Store.Contacts != nil {
 			storeUpdateError = cli.Store.Contacts.PutContactName(ctx, jid, act.GetFirstName(), act.GetFullName())
+			if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && storeUpdateError == nil {
+				storeUpdateError = usernameStore.PutContactUsername(ctx, jid, act.GetUsername())
+			}
 		}
 	case appstate.IndexClearChat:
 		act := mutation.Action.GetClearChatAction()

--- a/appstate.go
+++ b/appstate.go
@@ -223,9 +223,18 @@ func (cli *Client) filterContacts(mutations []appstate.Mutation) ([]appstate.Mut
 	filteredMutations := mutations[:0]
 	contacts := make([]store.ContactEntry, 0, len(mutations))
 	for _, mutation := range mutations {
-		if mutation.Index[0] == "contact" && len(mutation.Index) > 1 {
+		if len(mutation.Index) > 1 && mutation.Index[0] == appstate.IndexContact {
 			jid, _ := types.ParseJID(mutation.Index[1])
 			act := mutation.Action.GetContactAction()
+			contacts = append(contacts, store.ContactEntry{
+				JID:       jid,
+				FirstName: act.GetFirstName(),
+				FullName:  act.GetFullName(),
+				Username:  act.GetUsername(),
+			})
+		} else if len(mutation.Index) > 1 && mutation.Index[0] == appstate.IndexLIDContact {
+			jid, _ := types.ParseJID(mutation.Index[1])
+			act := mutation.Action.GetLidContactAction()
 			contacts = append(contacts, store.ContactEntry{
 				JID:       jid,
 				FirstName: act.GetFirstName(),
@@ -312,6 +321,14 @@ func (cli *Client) dispatchAppState(ctx context.Context, name appstate.WAPatchNa
 	case appstate.IndexContact:
 		act := mutation.Action.GetContactAction()
 		eventToDispatch = &events.Contact{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
+		if cli.Store.Contacts != nil {
+			storeUpdateError = cli.Store.Contacts.PutContactName(ctx, jid, act.GetFirstName(), act.GetFullName())
+			if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && storeUpdateError == nil {
+				storeUpdateError = usernameStore.PutContactUsername(ctx, jid, act.GetUsername())
+			}
+		}
+	case appstate.IndexLIDContact:
+		act := mutation.Action.GetLidContactAction()
 		if cli.Store.Contacts != nil {
 			storeUpdateError = cli.Store.Contacts.PutContactName(ctx, jid, act.GetFirstName(), act.GetFullName())
 			if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && storeUpdateError == nil {

--- a/binary/xml.go
+++ b/binary/xml.go
@@ -22,7 +22,7 @@ var (
 )
 
 func sensitiveXMLAttribute(key string) bool {
-	return key == "auth" || key == "token"
+	return key == "auth" || key == "pin" || key == "token"
 }
 
 func sensitiveXMLNodeContent(tag string) bool {

--- a/binary/xml_test.go
+++ b/binary/xml_test.go
@@ -38,12 +38,12 @@ func TestNodeStringRedactsSensitiveContent(t *testing.T) {
 func TestNodeStringRedactsSensitiveAttributes(t *testing.T) {
 	logged := (Node{
 		Tag:   "cover_photo",
-		Attrs: Attrs{"auth": "media-secret", "token": "upload-secret", "id": "cover-100"},
+		Attrs: Attrs{"auth": "media-secret", "pin": "1234", "token": "upload-secret", "id": "cover-100"},
 	}).String()
-	if strings.Contains(logged, "media-secret") || strings.Contains(logged, "upload-secret") {
+	if strings.Contains(logged, "media-secret") || strings.Contains(logged, "1234") || strings.Contains(logged, "upload-secret") {
 		t.Fatalf("sensitive attributes were not redacted: %s", logged)
 	}
-	if !strings.Contains(logged, `id="cover-100"`) || strings.Count(logged, "[redacted]") != 2 {
+	if !strings.Contains(logged, `id="cover-100"`) || strings.Count(logged, "[redacted]") != 3 {
 		t.Fatalf("unexpected redacted node: %s", logged)
 	}
 }

--- a/lid_resolution_test.go
+++ b/lid_resolution_test.go
@@ -23,17 +23,19 @@ func (cached *cachedLIDStore) GetLIDForPN(_ context.Context, pn types.JID) (type
 }
 
 func TestResolveLIDUsesCachedMapping(t *testing.T) {
-	pn := types.NewJID("15550001111", types.DefaultUserServer)
+	pn := types.NewADJID("15550001111", types.WhatsAppDomain, 7)
 	lid := types.NewJID("100000011111111", types.HiddenUserServer)
-	lids := &cachedLIDStore{pn: pn, lid: lid}
+	lids := &cachedLIDStore{pn: pn.ToNonAD(), lid: lid}
 	client := NewClient(&store.Device{LIDs: lids}, waLog.Noop)
 
 	resolved, err := client.resolveLID(context.Background(), pn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved != lid {
-		t.Fatalf("resolved LID = %s, want %s", resolved, lid)
+	want := lid
+	want.Device = pn.Device
+	if resolved != want {
+		t.Fatalf("resolved LID = %s, want %s", resolved, want)
 	}
 }
 

--- a/lid_resolution_test.go
+++ b/lid_resolution_test.go
@@ -1,0 +1,45 @@
+package whatsmeow
+
+import (
+	"context"
+	"testing"
+
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+type cachedLIDStore struct {
+	store.NoopStore
+	pn  types.JID
+	lid types.JID
+}
+
+func (cached *cachedLIDStore) GetLIDForPN(_ context.Context, pn types.JID) (types.JID, error) {
+	if pn.ToNonAD() == cached.pn {
+		return cached.lid, nil
+	}
+	return types.EmptyJID, nil
+}
+
+func TestResolveLIDUsesCachedMapping(t *testing.T) {
+	pn := types.NewJID("15550001111", types.DefaultUserServer)
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	lids := &cachedLIDStore{pn: pn, lid: lid}
+	client := NewClient(&store.Device{LIDs: lids}, waLog.Noop)
+
+	resolved, err := client.resolveLID(context.Background(), pn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != lid {
+		t.Fatalf("resolved LID = %s, want %s", resolved, lid)
+	}
+}
+
+func TestResolveLIDRejectsNonPhoneJID(t *testing.T) {
+	client := NewClient(&store.Device{LIDs: &store.NoopStore{}}, waLog.Noop)
+	if _, err := client.resolveLID(context.Background(), types.NewJID("100000011111111", types.HiddenUserServer)); err == nil {
+		t.Fatal("expected non-PN JID to fail")
+	}
+}

--- a/message.go
+++ b/message.go
@@ -343,14 +343,21 @@ func (cli *Client) decryptMessages(ctx context.Context, info *types.MessageInfo,
 		if info.SenderAlt.Server == types.HiddenUserServer {
 			senderEncryptionJID = info.SenderAlt
 			cli.migrateSessionStore(ctx, info.Sender, info.SenderAlt)
-		} else if lid, err := cli.Store.LIDs.GetLIDForPN(ctx, info.Sender); err != nil {
-			cli.Log.Errorf("Failed to get LID for %s: %v", info.Sender, err)
-		} else if !lid.IsEmpty() {
+		} else if lid, err := cli.resolveLID(ctx, info.Sender); err != nil {
+			cli.Log.Errorf("Failed to resolve LID for %s: %v", info.Sender, err)
+			if cli.SynchronousAck {
+				cli.sendRetryReceipt(ctx, node, info, false)
+				cli.sendAck(ctx, node, 0)
+			} else {
+				go cli.sendRetryReceipt(context.WithoutCancel(ctx), node, info, false)
+				go cli.sendAck(ctx, node, 0)
+			}
+			cli.dispatchEvent(&events.UndecryptableMessage{Info: *info})
+			return
+		} else {
 			cli.migrateSessionStore(ctx, info.Sender, lid)
 			senderEncryptionJID = lid
 			info.SenderAlt = lid
-		} else {
-			cli.Log.Warnf("No LID found for %s", info.Sender)
 		}
 	}
 	var recognizedStanza, protobufFailed bool
@@ -812,6 +819,9 @@ func (cli *Client) DownloadHistorySync(ctx context.Context, notif *waE2E.History
 		if len(historySync.GetPhoneNumberToLidMappings()) > 0 {
 			cli.storeHistoricalPNLIDMappings(ctx, historySync.GetPhoneNumberToLidMappings())
 		}
+		if len(historySync.GetInlineContacts()) > 0 {
+			cli.storeHistoricalInlineContacts(ctx, historySync.GetInlineContacts())
+		}
 		if historySync.GetSyncType() == waHistorySync.HistorySync_PUSH_NAME {
 			cli.handleHistoricalPushNames(ctx, historySync.GetPushnames())
 		} else if len(historySync.GetConversations()) > 0 {
@@ -829,6 +839,49 @@ func (cli *Client) DownloadHistorySync(ctx context.Context, notif *waE2E.History
 		go doStorage(storageCtx)
 	}
 	return &historySync, nil
+}
+
+func historicalInlineContactEntries(contacts []*waHistorySync.InlineContact) ([]store.ContactEntry, []store.LIDMapping) {
+	entries := make([]store.ContactEntry, 0, len(contacts))
+	mappings := make([]store.LIDMapping, 0, len(contacts))
+	for _, contact := range contacts {
+		if contact == nil {
+			continue
+		}
+		pn, _ := types.ParseJID(contact.GetPnJID())
+		lid, _ := types.ParseJID(contact.GetLidJID())
+		if pn.Server == types.DefaultUserServer && lid.Server == types.HiddenUserServer {
+			mappings = append(mappings, store.LIDMapping{PN: pn.ToNonAD(), LID: lid.ToNonAD()})
+		}
+		jid := lid.ToNonAD()
+		if jid.Server != types.HiddenUserServer {
+			jid = pn.ToNonAD()
+		}
+		if jid.Server != types.HiddenUserServer && jid.Server != types.DefaultUserServer {
+			continue
+		}
+		entries = append(entries, store.ContactEntry{
+			JID:       jid,
+			FirstName: contact.GetFirstName(),
+			FullName:  contact.GetFullName(),
+			Username:  contact.GetUsername(),
+		})
+	}
+	return entries, mappings
+}
+
+func (cli *Client) storeHistoricalInlineContacts(ctx context.Context, contacts []*waHistorySync.InlineContact) {
+	entries, mappings := historicalInlineContactEntries(contacts)
+	if len(mappings) > 0 {
+		if err := cli.Store.LIDs.PutManyLIDMappings(ctx, mappings); err != nil {
+			cli.Log.Warnf("Failed to store LID mappings from inline contacts: %v", err)
+		}
+	}
+	if len(entries) > 0 && cli.Store.Contacts != nil {
+		if err := cli.Store.Contacts.PutAllContactNames(ctx, entries); err != nil {
+			cli.Log.Warnf("Failed to store inline contacts: %v", err)
+		}
+	}
 }
 
 func (cli *Client) handleAppStateSyncKeyShare(ctx context.Context, keys *waE2E.AppStateSyncKeyShare) {

--- a/message.go
+++ b/message.go
@@ -861,10 +861,11 @@ func historicalInlineContactEntries(contacts []*waHistorySync.InlineContact) ([]
 			continue
 		}
 		entries = append(entries, store.ContactEntry{
-			JID:       jid,
-			FirstName: contact.GetFirstName(),
-			FullName:  contact.GetFullName(),
-			Username:  contact.GetUsername(),
+			JID:         jid,
+			FirstName:   contact.GetFirstName(),
+			FullName:    contact.GetFullName(),
+			Username:    contact.GetUsername(),
+			UsernameSet: true,
 		})
 	}
 	return entries, mappings

--- a/send.go
+++ b/send.go
@@ -337,21 +337,10 @@ func (cli *Client) SendMessage(ctx context.Context, to types.JID, message *waE2E
 	} else if to.Server == types.DefaultUserServer && !req.Peer {
 		start := time.Now()
 		var toLID types.JID
-		toLID, err = cli.Store.LIDs.GetLIDForPN(ctx, to)
+		toLID, err = cli.resolveLID(ctx, to)
 		if err != nil {
-			err = fmt.Errorf("failed to get LID for PN %s: %w", to, err)
+			err = fmt.Errorf("failed to resolve LID for PN %s: %w", to, err)
 			return
-		} else if toLID.IsEmpty() {
-			var info map[types.JID]types.UserInfo
-			cli.Log.Debugf("LID for %s not found, fetching user info", to)
-			info, err = cli.GetUserInfo(ctx, []types.JID{to})
-			if err != nil {
-				err = fmt.Errorf("failed to get user info for %s to fill LID cache: %w", to, err)
-				return
-			} else if toLID = info[to].LID; toLID.IsEmpty() {
-				err = fmt.Errorf("no LID found for %s from server", to)
-				return
-			}
 		}
 		resp.DebugTimings.LIDFetch = time.Since(start)
 		cli.Log.Debugf("Replacing SendMessage destination with LID %s -> %s", to, toLID)

--- a/store/clientpayload.go
+++ b/store/clientpayload.go
@@ -151,6 +151,7 @@ var DeviceProps = &waCompanionReg.DeviceProps{
 		InitialSyncMaxMessagesPerChat:            nil,
 		SupportManusHistory:                      proto.Bool(true),
 		SupportHatchHistory:                      proto.Bool(true),
+		SupportInlineContacts:                    proto.Bool(true),
 	},
 	PlatformType:    waCompanionReg.DeviceProps_UNKNOWN.Enum(),
 	RequireFullSync: proto.Bool(false),

--- a/store/clientpayload_test.go
+++ b/store/clientpayload_test.go
@@ -1,0 +1,9 @@
+package store
+
+import "testing"
+
+func TestDevicePropsAdvertiseInlineContacts(t *testing.T) {
+	if !DeviceProps.GetHistorySyncConfig().GetSupportInlineContacts() {
+		t.Fatal("device properties do not advertise inline contact history")
+	}
+}

--- a/store/contact_test.go
+++ b/store/contact_test.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestContactEntryMassInsertIncludesUsername(t *testing.T) {
+	entry := ContactEntry{
+		JID:       types.NewJID("100000011111111", types.HiddenUserServer),
+		FirstName: "Example",
+		FullName:  "Example User",
+		Username:  "example",
+	}
+	values := entry.GetMassInsertValues()
+	if values[3] != "example" {
+		t.Fatalf("username value = %#v", values[3])
+	}
+}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -857,8 +857,11 @@ const (
 	`
 	putContactNamesQuery = `
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, first_name, full_name, username) VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name,
-			username=CASE WHEN excluded.username <> '' THEN excluded.username ELSE whatsmeow_contacts.username END
+		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name, username=excluded.username
+	`
+	putContactNamesWithoutUsernameQuery = `
+		INSERT INTO whatsmeow_contacts (our_jid, their_jid, first_name, full_name) VALUES ($1, $2, $3, $4)
+		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name
 	`
 	putContactUsernameQuery = `
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, username) VALUES ($1, $2, $3)
@@ -888,6 +891,29 @@ const (
 var putContactNamesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.ContactEntry, [1]any](
 	putContactNamesQuery, "($1, $%d, $%d, $%d, $%d)",
 )
+
+type contactNameEntryWithoutUsername store.ContactEntry
+
+func (entry contactNameEntryWithoutUsername) GetMassInsertValues() [3]any {
+	return [...]any{entry.JID.String(), entry.FirstName, entry.FullName}
+}
+
+var putContactNamesWithoutUsernameMassInsertBuilder = dbutil.NewMassInsertBuilder[contactNameEntryWithoutUsername, [1]any](
+	putContactNamesWithoutUsernameQuery, "($1, $%d, $%d, $%d)",
+)
+
+func splitContactNameEntries(contacts []store.ContactEntry) ([]store.ContactEntry, []contactNameEntryWithoutUsername) {
+	withUsername := make([]store.ContactEntry, 0, len(contacts))
+	withoutUsername := make([]contactNameEntryWithoutUsername, 0, len(contacts))
+	for _, contact := range contacts {
+		if contact.UsernameSet || contact.Username != "" {
+			withUsername = append(withUsername, contact)
+		} else {
+			withoutUsername = append(withoutUsername, contactNameEntryWithoutUsername(contact))
+		}
+	}
+	return withUsername, withoutUsername
+}
 
 var putRedactedPhonesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.RedactedPhoneEntry, [1]any](
 	putRedactedPhoneQuery, "($1, $%d, $%d)",
@@ -986,11 +1012,18 @@ func (s *SQLStore) PutAllContactNames(ctx context.Context, contacts []store.Cont
 	if origLen != len(contacts) {
 		s.log.Warnf("%d duplicate contacts found in PutAllContactNames", origLen-len(contacts))
 	}
+	withUsername, withoutUsername := splitContactNameEntries(contacts)
 	err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
-		for slice := range slices.Chunk(contacts, contactBatchSize) {
+		for slice := range slices.Chunk(withUsername, contactBatchSize) {
 			query, vars := putContactNamesMassInsertBuilder.Build([1]any{s.JID}, slice)
 			_, err := s.db.Exec(ctx, query, vars...)
 			if err != nil {
+				return err
+			}
+		}
+		for slice := range slices.Chunk(withoutUsername, contactBatchSize) {
+			query, vars := putContactNamesWithoutUsernameMassInsertBuilder.Build([1]any{s.JID}, slice)
+			if _, err := s.db.Exec(ctx, query, vars...); err != nil {
 				return err
 			}
 		}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -855,6 +855,14 @@ const (
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, first_name, full_name) VALUES ($1, $2, $3, $4)
 		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name
 	`
+	putContactNamesQuery = `
+		INSERT INTO whatsmeow_contacts (our_jid, their_jid, first_name, full_name, username) VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name, username=excluded.username
+	`
+	putContactUsernameQuery = `
+		INSERT INTO whatsmeow_contacts (our_jid, their_jid, username) VALUES ($1, $2, $3)
+		ON CONFLICT (our_jid, their_jid) DO UPDATE SET username=excluded.username
+	`
 	putRedactedPhoneQuery = `
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, redacted_phone)
 		VALUES ($1, $2, $3)
@@ -869,15 +877,15 @@ const (
 		ON CONFLICT (our_jid, their_jid) DO UPDATE SET business_name=excluded.business_name
 	`
 	getContactQuery = `
-		SELECT first_name, full_name, push_name, business_name, redacted_phone FROM whatsmeow_contacts WHERE our_jid=$1 AND their_jid=$2
+		SELECT first_name, full_name, push_name, business_name, redacted_phone, username FROM whatsmeow_contacts WHERE our_jid=$1 AND their_jid=$2
 	`
 	getAllContactsQuery = `
-		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone FROM whatsmeow_contacts WHERE our_jid=$1
+		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone, username FROM whatsmeow_contacts WHERE our_jid=$1
 	`
 )
 
 var putContactNamesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.ContactEntry, [1]any](
-	putContactNameQuery, "($1, $%d, $%d, $%d)",
+	putContactNamesQuery, "($1, $%d, $%d, $%d, $%d)",
 )
 
 var putRedactedPhonesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.RedactedPhoneEntry, [1]any](
@@ -941,6 +949,24 @@ func (s *SQLStore) PutContactName(ctx context.Context, user types.JID, firstName
 		}
 		cached.FirstName = firstName
 		cached.FullName = fullName
+		cached.Found = true
+	}
+	return nil
+}
+
+func (s *SQLStore) PutContactUsername(ctx context.Context, user types.JID, username string) error {
+	s.contactCacheLock.Lock()
+	defer s.contactCacheLock.Unlock()
+
+	cached, err := s.getContact(ctx, user)
+	if err != nil {
+		return err
+	}
+	if cached.Username != username {
+		if _, err = s.db.Exec(ctx, putContactUsernameQuery, s.JID, user, username); err != nil {
+			return err
+		}
+		cached.Username = username
 		cached.Found = true
 	}
 	return nil
@@ -1020,8 +1046,8 @@ func (s *SQLStore) getContact(ctx context.Context, user types.JID) (*types.Conta
 		return cached, nil
 	}
 
-	var first, full, push, business, redactedPhone sql.NullString
-	err := s.db.QueryRow(ctx, getContactQuery, s.JID, user).Scan(&first, &full, &push, &business, &redactedPhone)
+	var first, full, push, business, redactedPhone, username sql.NullString
+	err := s.db.QueryRow(ctx, getContactQuery, s.JID, user).Scan(&first, &full, &push, &business, &redactedPhone, &username)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
@@ -1032,6 +1058,7 @@ func (s *SQLStore) getContact(ctx context.Context, user types.JID) (*types.Conta
 		PushName:      push.String,
 		BusinessName:  business.String,
 		RedactedPhone: redactedPhone.String,
+		Username:      username.String,
 	}
 	s.setCachedContactLocked(user, info)
 	return info, nil
@@ -1054,8 +1081,8 @@ type contactTuple struct {
 
 var convertContactRow = dbutil.ConvertRowFn[*contactTuple](func(rows dbutil.Scannable) (*contactTuple, error) {
 	var jid types.JID
-	var first, full, push, business, redactedPhone sql.NullString
-	err := rows.Scan(&jid, &first, &full, &push, &business, &redactedPhone)
+	var first, full, push, business, redactedPhone, username sql.NullString
+	err := rows.Scan(&jid, &first, &full, &push, &business, &redactedPhone, &username)
 	if err != nil {
 		return nil, fmt.Errorf("error scanning row: %w", err)
 	}
@@ -1068,6 +1095,7 @@ var convertContactRow = dbutil.ConvertRowFn[*contactTuple](func(rows dbutil.Scan
 			PushName:      push.String,
 			BusinessName:  business.String,
 			RedactedPhone: redactedPhone.String,
+			Username:      username.String,
 		},
 	}, nil
 })

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -857,7 +857,8 @@ const (
 	`
 	putContactNamesQuery = `
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, first_name, full_name, username) VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name, username=excluded.username
+		ON CONFLICT (our_jid, their_jid) DO UPDATE SET first_name=excluded.first_name, full_name=excluded.full_name,
+			username=CASE WHEN excluded.username <> '' THEN excluded.username ELSE whatsmeow_contacts.username END
 	`
 	putContactUsernameQuery = `
 		INSERT INTO whatsmeow_contacts (our_jid, their_jid, username) VALUES ($1, $2, $3)

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -84,8 +85,16 @@ func TestBuildSharedMassInsertQuery(t *testing.T) {
 }
 
 func TestBulkContactNamesPreserveMissingUsername(t *testing.T) {
-	if !strings.Contains(putContactNamesQuery, "CASE WHEN excluded.username <> '' THEN excluded.username ELSE whatsmeow_contacts.username END") {
-		t.Fatal("bulk contact-name update does not preserve an omitted username")
+	withUsername, withoutUsername := splitContactNameEntries([]store.ContactEntry{
+		{JID: types.NewJID("100", types.HiddenUserServer)},
+		{JID: types.NewJID("101", types.HiddenUserServer), Username: "named"},
+		{JID: types.NewJID("102", types.HiddenUserServer), UsernameSet: true},
+	})
+	if len(withoutUsername) != 1 || withoutUsername[0].JID.User != "100" {
+		t.Fatalf("name-only contacts = %#v", withoutUsername)
+	}
+	if len(withUsername) != 2 || withUsername[0].Username != "named" || !withUsername[1].UsernameSet || withUsername[1].Username != "" {
+		t.Fatalf("username-aware contacts = %#v", withUsername)
 	}
 }
 

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -83,6 +83,12 @@ func TestBuildSharedMassInsertQuery(t *testing.T) {
 	}
 }
 
+func TestBulkContactNamesPreserveMissingUsername(t *testing.T) {
+	if !strings.Contains(putContactNamesQuery, "CASE WHEN excluded.username <> '' THEN excluded.username ELSE whatsmeow_contacts.username END") {
+		t.Fatal("bulk contact-name update does not preserve an omitted username")
+	}
+}
+
 func TestIdentityCacheIsBounded(t *testing.T) {
 	store := &SQLStore{identityCache: make(map[string]identityCacheEntry, maxIdentityCacheEntries)}
 	for i := 0; i < maxIdentityCacheEntries; i++ {

--- a/store/sqlstore/upgrades/00-latest-schema.sql
+++ b/store/sqlstore/upgrades/00-latest-schema.sql
@@ -114,6 +114,7 @@ CREATE TABLE whatsmeow_contacts (
 	push_name      TEXT,
 	business_name  TEXT,
 	redacted_phone TEXT,
+	username       TEXT,
 
 	PRIMARY KEY (our_jid, their_jid),
 	FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE

--- a/store/sqlstore/upgrades/00-latest-schema.sql
+++ b/store/sqlstore/upgrades/00-latest-schema.sql
@@ -1,4 +1,4 @@
--- v0 -> v17 (compatible with v8+): Latest schema
+-- v0 -> v18 (compatible with v8+): Latest schema
 CREATE TABLE whatsmeow_device (
 	jid TEXT PRIMARY KEY,
 	lid TEXT,

--- a/store/sqlstore/upgrades/17-contact-username.sql
+++ b/store/sqlstore/upgrades/17-contact-username.sql
@@ -1,2 +1,0 @@
--- v17: Persist the optional WhatsApp username alongside the LID-keyed contact.
-ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;

--- a/store/sqlstore/upgrades/17-contact-username.sql
+++ b/store/sqlstore/upgrades/17-contact-username.sql
@@ -1,0 +1,2 @@
+-- v17: Persist the optional WhatsApp username alongside the LID-keyed contact.
+ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;

--- a/store/sqlstore/upgrades/18-contact-username.sql
+++ b/store/sqlstore/upgrades/18-contact-username.sql
@@ -1,2 +1,2 @@
--- v18: Persist the optional WhatsApp username alongside the LID-keyed contact.
+-- v18 (compatible with v8+): Persist the optional WhatsApp username alongside the LID-keyed contact.
 ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;

--- a/store/sqlstore/upgrades/18-contact-username.sql
+++ b/store/sqlstore/upgrades/18-contact-username.sql
@@ -1,0 +1,2 @@
+-- v18: Persist the optional WhatsApp username alongside the LID-keyed contact.
+ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;

--- a/store/sqlstore/upgrades/upgrades_test.go
+++ b/store/sqlstore/upgrades/upgrades_test.go
@@ -153,8 +153,8 @@ func TestUpgradeFromCurrentDevSchemaAddsUsername(t *testing.T) {
 	if err = db.Upgrade(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if state.version != 18 || state.compatVersion != 18 {
-		t.Fatalf("schema version = %d/%d, want 18/18", state.version, state.compatVersion)
+	if state.version != 18 || state.compatVersion != 8 {
+		t.Fatalf("schema version = %d/%d, want 18/8", state.version, state.compatVersion)
 	}
 	want := "ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;"
 	for _, query := range state.executed {

--- a/store/sqlstore/upgrades/upgrades_test.go
+++ b/store/sqlstore/upgrades/upgrades_test.go
@@ -1,0 +1,166 @@
+package upgrades
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.mau.fi/util/dbutil"
+)
+
+var upgradeVersionPattern = regexp.MustCompile(`^-- (?:v(\d+) -> )?v(\d+)`)
+
+func TestUpgradeSourcesHaveUniqueStartingVersions(t *testing.T) {
+	entries, err := fs.ReadDir(upgrades, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions := make(map[int]string)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		file, err := upgrades.Open(entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanner := bufio.NewScanner(file)
+		if !scanner.Scan() {
+			_ = file.Close()
+			t.Fatalf("%s has no upgrade header", entry.Name())
+		}
+		_ = file.Close()
+		matches := upgradeVersionPattern.FindStringSubmatch(scanner.Text())
+		if matches == nil {
+			t.Fatalf("%s has an invalid upgrade header", entry.Name())
+		}
+		to, err := strconv.Atoi(matches[2])
+		if err != nil {
+			t.Fatal(err)
+		}
+		from := to - 1
+		if matches[1] != "" {
+			from, err = strconv.Atoi(matches[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if previous, exists := versions[from]; exists {
+			t.Fatalf("%s and %s both register an upgrade starting at v%d", previous, entry.Name(), from)
+		}
+		versions[from] = entry.Name()
+	}
+}
+
+type upgradeTestState struct {
+	executed      []string
+	version       int64
+	compatVersion int64
+}
+
+type upgradeTestConnector struct{ state *upgradeTestState }
+
+func (c *upgradeTestConnector) Connect(context.Context) (driver.Conn, error) {
+	return &upgradeTestConn{state: c.state}, nil
+}
+
+func (*upgradeTestConnector) Driver() driver.Driver { return upgradeTestDriver{} }
+
+type upgradeTestDriver struct{}
+
+func (upgradeTestDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("use connector")
+}
+
+type upgradeTestConn struct{ state *upgradeTestState }
+
+func (*upgradeTestConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("unexpected prepare")
+}
+
+func (*upgradeTestConn) Close() error { return nil }
+
+func (c *upgradeTestConn) Begin() (driver.Tx, error) { return &upgradeTestTx{}, nil }
+
+func (c *upgradeTestConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return &upgradeTestTx{}, nil
+}
+
+func (c *upgradeTestConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	switch {
+	case strings.Contains(query, "information_schema.columns"):
+		return &upgradeTestRows{columns: []string{"exists"}, values: []driver.Value{true}}, nil
+	case strings.HasPrefix(query, "SELECT version, compat FROM whatsmeow_version"):
+		return &upgradeTestRows{columns: []string{"version", "compat"}, values: []driver.Value{c.state.version, c.state.compatVersion}}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", query)
+	}
+}
+
+func (c *upgradeTestConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.state.executed = append(c.state.executed, query)
+	if strings.HasPrefix(query, "INSERT INTO whatsmeow_version") {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("unexpected version argument count: %d", len(args))
+		}
+		c.state.version = args[0].Value.(int64)
+		c.state.compatVersion = args[1].Value.(int64)
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type upgradeTestTx struct{}
+
+func (*upgradeTestTx) Commit() error   { return nil }
+func (*upgradeTestTx) Rollback() error { return nil }
+
+type upgradeTestRows struct {
+	columns []string
+	values  []driver.Value
+	read    bool
+}
+
+func (r *upgradeTestRows) Columns() []string { return r.columns }
+func (*upgradeTestRows) Close() error        { return nil }
+func (r *upgradeTestRows) Next(values []driver.Value) error {
+	if r.read {
+		return io.EOF
+	}
+	r.read = true
+	copy(values, r.values)
+	return nil
+}
+
+func TestUpgradeFromCurrentDevSchemaAddsUsername(t *testing.T) {
+	state := &upgradeTestState{version: 17, compatVersion: 8}
+	rawDB := sql.OpenDB(&upgradeTestConnector{state: state})
+	t.Cleanup(func() { _ = rawDB.Close() })
+	db, err := dbutil.NewWithDB(rawDB, "postgres")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.VersionTable = "whatsmeow_version"
+	db.UpgradeTable = Table
+	if err = db.Upgrade(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if state.version != 18 || state.compatVersion != 18 {
+		t.Fatalf("schema version = %d/%d, want 18/18", state.version, state.compatVersion)
+	}
+	want := "ALTER TABLE whatsmeow_contacts ADD COLUMN username TEXT;"
+	for _, query := range state.executed {
+		if strings.TrimSpace(query) == want {
+			return
+		}
+	}
+	t.Fatalf("username migration was not executed: %q", state.executed)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -85,10 +85,11 @@ type ContactEntry struct {
 	JID       types.JID
 	FirstName string
 	FullName  string
+	Username  string
 }
 
-func (ce ContactEntry) GetMassInsertValues() [3]any {
-	return [...]any{ce.JID.String(), ce.FirstName, ce.FullName}
+func (ce ContactEntry) GetMassInsertValues() [4]any {
+	return [...]any{ce.JID.String(), ce.FirstName, ce.FullName, ce.Username}
 }
 
 type RedactedPhoneEntry struct {
@@ -108,6 +109,10 @@ type ContactStore interface {
 	PutManyRedactedPhones(ctx context.Context, entries []RedactedPhoneEntry) error
 	GetContact(ctx context.Context, user types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
+}
+
+type ContactUsernameStore interface {
+	PutContactUsername(ctx context.Context, user types.JID, username string) error
 }
 
 var MutedForever = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)

--- a/store/store.go
+++ b/store/store.go
@@ -82,10 +82,11 @@ type AppStateStore interface {
 }
 
 type ContactEntry struct {
-	JID       types.JID
-	FirstName string
-	FullName  string
-	Username  string
+	JID         types.JID
+	FirstName   string
+	FullName    string
+	Username    string
+	UsernameSet bool
 }
 
 func (ce ContactEntry) GetMassInsertValues() [4]any {

--- a/types/events/appstate.go
+++ b/types/events/appstate.go
@@ -23,6 +23,15 @@ type Contact struct {
 	FromFullSync bool                        // Whether the action is emitted because of a fullSync
 }
 
+// LIDContact is emitted when a LID-keyed contact is modified from another device.
+type LIDContact struct {
+	JID       types.JID
+	Timestamp time.Time
+
+	Action       *waSyncAction.LidContactAction
+	FromFullSync bool
+}
+
 // PushName is emitted when a message is received with a different push name than the previous value cached for the same user.
 type PushName struct {
 	JID         types.JID // The user whose push name changed.

--- a/types/user.go
+++ b/types/user.go
@@ -33,6 +33,7 @@ type UserInfo struct {
 	PictureID    string
 	Devices      []JID
 	LID          JID
+	Username     string
 }
 
 type BotListInfo struct {
@@ -77,6 +78,7 @@ type ContactInfo struct {
 	FullName     string
 	PushName     string
 	BusinessName string
+	Username     string
 	// Only for LID members encountered in groups, the phone number in the form "+1∙∙∙∙∙∙∙∙80"
 	RedactedPhone string
 }
@@ -99,6 +101,12 @@ type IsOnWhatsAppResponse struct {
 	PhoneNumber JID
 
 	VerifiedName *VerifiedName // If the phone is a business, the verified business details.
+}
+
+type UsernameResolution struct {
+	LID         JID
+	Username    string
+	KeyRequired bool
 }
 
 // BusinessMessageLinkTarget contains the info that is found using a business message link (see Client.ResolveBusinessMessageLink)

--- a/user.go
+++ b/user.go
@@ -236,6 +236,7 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 		{Tag: "picture"},
 		{Tag: "devices", Attrs: waBinary.Attrs{"version": "2"}},
 		{Tag: "lid"},
+		{Tag: "username"},
 	}, UsyncQueryExtras{
 		IncludePrivacyToken: true,
 	})
@@ -261,6 +262,8 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 
 		lidTag := child.GetChildByTag("lid")
 		info.LID = lidTag.AttrGetter().OptionalJIDOrEmpty("val")
+		username, _ := child.GetChildByTag("username").Content.([]byte)
+		info.Username = string(username)
 
 		if !info.LID.IsEmpty() {
 			mappings = append(mappings, store.LIDMapping{PN: jid, LID: info.LID})
@@ -270,6 +273,15 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 			cli.updateBusinessName(ctx, jid, info.LID, nil, verifiedName.Details.GetVerifiedName())
 		}
 		respData[jid] = info
+		if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && info.Username != "" {
+			usernameJID := info.LID
+			if usernameJID.IsEmpty() {
+				usernameJID = jid
+			}
+			if err := usernameStore.PutContactUsername(ctx, usernameJID, info.Username); err != nil {
+				cli.Log.Warnf("Failed to store username for %s: %v", usernameJID, err)
+			}
+		}
 	}
 
 	err = cli.Store.LIDs.PutManyLIDMappings(ctx, mappings)
@@ -279,6 +291,95 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 	}
 
 	return respData, nil
+}
+
+var ErrUsernameNotFound = errors.New("username not found")
+
+func parseUsernameResolution(list *waBinary.Node) (types.UsernameResolution, error) {
+	children := list.GetChildren()
+	if len(children) != 1 || children[0].Tag != "user" {
+		return types.UsernameResolution{}, ErrUsernameNotFound
+	}
+	user := children[0]
+	contact := user.GetChildByTag("contact")
+	contactAttrs := contact.AttrGetter()
+	if contactAttrs.OptionalString("type") == "out" {
+		return types.UsernameResolution{}, ErrUsernameNotFound
+	}
+	lid := user.AttrGetter().OptionalJIDOrEmpty("jid").ToNonAD()
+	if lid.IsEmpty() {
+		return types.UsernameResolution{KeyRequired: true}, nil
+	}
+	if lid.Server != types.HiddenUserServer {
+		return types.UsernameResolution{}, fmt.Errorf("username resolved to non-LID JID %s", lid)
+	}
+	return types.UsernameResolution{
+		LID:      lid,
+		Username: contactAttrs.OptionalString("username"),
+	}, nil
+}
+
+func (cli *Client) ResolveUsername(ctx context.Context, username, key string) (types.UsernameResolution, error) {
+	username = strings.TrimPrefix(strings.TrimSpace(username), "@")
+	if len(username) < 3 || len(username) > 35 {
+		return types.UsernameResolution{}, fmt.Errorf("username must contain 3 to 35 characters")
+	}
+	if key != "" {
+		if len(key) != 4 {
+			return types.UsernameResolution{}, fmt.Errorf("username key must contain 4 digits")
+		}
+		for _, char := range key {
+			if char < '0' || char > '9' {
+				return types.UsernameResolution{}, fmt.Errorf("username key must contain 4 digits")
+			}
+		}
+	}
+	list, err := cli.usync(ctx, []types.JID{types.EmptyJID}, "query", "interactive", []waBinary.Node{
+		{Tag: "contact", Attrs: waBinary.Attrs{"addressing_mode": "lid"}},
+		{Tag: "business", Content: []waBinary.Node{{Tag: "verified_name"}}},
+	}, UsyncQueryExtras{Username: username, UsernameKey: key})
+	if err != nil {
+		return types.UsernameResolution{}, err
+	}
+	result, err := parseUsernameResolution(list)
+	if err != nil || result.KeyRequired {
+		return result, err
+	}
+	if result.Username == "" {
+		result.Username = username
+	}
+	if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok {
+		if err = usernameStore.PutContactUsername(ctx, result.LID, result.Username); err != nil {
+			cli.Log.Warnf("Failed to store username for %s: %v", result.LID, err)
+		}
+	}
+	return result, nil
+}
+
+func (cli *Client) resolveLID(ctx context.Context, phone types.JID) (types.JID, error) {
+	phone = phone.ToNonAD()
+	if phone.Server != types.DefaultUserServer {
+		return types.EmptyJID, fmt.Errorf("cannot resolve non-PN JID %s to LID", phone)
+	}
+	if cli.Store == nil || cli.Store.LIDs == nil {
+		return types.EmptyJID, fmt.Errorf("LID store is unavailable")
+	}
+	lid, err := cli.Store.LIDs.GetLIDForPN(ctx, phone)
+	if err != nil {
+		return types.EmptyJID, fmt.Errorf("get cached LID for %s: %w", phone, err)
+	}
+	if !lid.IsEmpty() {
+		return lid.ToNonAD(), nil
+	}
+	info, err := cli.GetUserInfo(ctx, []types.JID{phone})
+	if err != nil {
+		return types.EmptyJID, fmt.Errorf("resolve LID for %s with USync: %w", phone, err)
+	}
+	lid = info[phone].LID.ToNonAD()
+	if lid.IsEmpty() {
+		return types.EmptyJID, fmt.Errorf("USync returned no LID for %s", phone)
+	}
+	return lid, nil
 }
 
 func (cli *Client) GetBotListV2(ctx context.Context) ([]types.BotListInfo, error) {
@@ -882,6 +983,8 @@ func (cli *Client) getFBIDDevices(ctx context.Context, jids []types.JID) ([]type
 type UsyncQueryExtras struct {
 	BotListInfo         []types.BotListInfo
 	IncludePrivacyToken bool
+	Username            string
+	UsernameKey         string
 }
 
 func (cli *Client) usync(ctx context.Context, jids []types.JID, mode, context string, query []waBinary.Node, extra ...UsyncQueryExtras) (*waBinary.Node, error) {
@@ -899,6 +1002,14 @@ func (cli *Client) usync(ctx context.Context, jids []types.JID, mode, context st
 	for i, jid := range jids {
 		userList[i].Tag = "user"
 		jid = jid.ToNonAD()
+		if extras.Username != "" {
+			attrs := waBinary.Attrs{"username": extras.Username}
+			if extras.UsernameKey != "" {
+				attrs["pin"] = extras.UsernameKey
+			}
+			userList[i].Content = []waBinary.Node{{Tag: "contact", Attrs: attrs}}
+			continue
+		}
 
 		switch jid.Server {
 		case types.LegacyUserServer:

--- a/user.go
+++ b/user.go
@@ -357,6 +357,7 @@ func (cli *Client) ResolveUsername(ctx context.Context, username, key string) (t
 }
 
 func (cli *Client) resolveLID(ctx context.Context, phone types.JID) (types.JID, error) {
+	device := phone.Device
 	phone = phone.ToNonAD()
 	if phone.Server != types.DefaultUserServer {
 		return types.EmptyJID, fmt.Errorf("cannot resolve non-PN JID %s to LID", phone)
@@ -369,7 +370,9 @@ func (cli *Client) resolveLID(ctx context.Context, phone types.JID) (types.JID, 
 		return types.EmptyJID, fmt.Errorf("get cached LID for %s: %w", phone, err)
 	}
 	if !lid.IsEmpty() {
-		return lid.ToNonAD(), nil
+		lid = lid.ToNonAD()
+		lid.Device = device
+		return lid, nil
 	}
 	info, err := cli.GetUserInfo(ctx, []types.JID{phone})
 	if err != nil {
@@ -379,6 +382,7 @@ func (cli *Client) resolveLID(ctx context.Context, phone types.JID) (types.JID, 
 	if lid.IsEmpty() {
 		return types.EmptyJID, fmt.Errorf("USync returned no LID for %s", phone)
 	}
+	lid.Device = device
 	return lid, nil
 }
 

--- a/username_contact_test.go
+++ b/username_contact_test.go
@@ -1,0 +1,27 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waSyncAction"
+)
+
+func TestFilterContactsPreservesUsername(t *testing.T) {
+	client := &Client{}
+	_, contacts := client.filterContacts([]appstate.Mutation{{
+		Index: []string{"contact", "100000011111111@lid"},
+		Action: &waSyncAction.SyncActionValue{ContactAction: &waSyncAction.ContactAction{
+			FullName: proto.String("Example User"),
+			Username: proto.String("example"),
+		}},
+	}})
+	if len(contacts) != 1 {
+		t.Fatalf("got %d contacts", len(contacts))
+	}
+	if contacts[0].Username != "example" {
+		t.Fatalf("username = %q", contacts[0].Username)
+	}
+}

--- a/username_contact_test.go
+++ b/username_contact_test.go
@@ -37,6 +37,9 @@ func TestFilterContactsPreservesUsername(t *testing.T) {
 	if contacts[0].Username != "example" || contacts[1].Username != "lid-example" {
 		t.Fatalf("usernames = %q, %q", contacts[0].Username, contacts[1].Username)
 	}
+	if !contacts[0].UsernameSet || !contacts[1].UsernameSet {
+		t.Fatal("snapshot usernames were not marked authoritative")
+	}
 }
 
 type recordingLIDContactStore struct {

--- a/username_contact_test.go
+++ b/username_contact_test.go
@@ -1,27 +1,73 @@
 package whatsmeow
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
 
 	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waSyncAction"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestFilterContactsPreservesUsername(t *testing.T) {
 	client := &Client{}
-	_, contacts := client.filterContacts([]appstate.Mutation{{
-		Index: []string{"contact", "100000011111111@lid"},
-		Action: &waSyncAction.SyncActionValue{ContactAction: &waSyncAction.ContactAction{
-			FullName: proto.String("Example User"),
-			Username: proto.String("example"),
-		}},
-	}})
-	if len(contacts) != 1 {
+	_, contacts := client.filterContacts([]appstate.Mutation{
+		{
+			Index: []string{appstate.IndexContact, "100000011111111@lid"},
+			Action: &waSyncAction.SyncActionValue{ContactAction: &waSyncAction.ContactAction{
+				FullName: proto.String("Example User"),
+				Username: proto.String("example"),
+			}},
+		},
+		{
+			Index: []string{appstate.IndexLIDContact, "100000022222222@lid"},
+			Action: &waSyncAction.SyncActionValue{LidContactAction: &waSyncAction.LidContactAction{
+				FullName: proto.String("LID User"),
+				Username: proto.String("lid-example"),
+			}},
+		},
+	})
+	if len(contacts) != 2 {
 		t.Fatalf("got %d contacts", len(contacts))
 	}
-	if contacts[0].Username != "example" {
-		t.Fatalf("username = %q", contacts[0].Username)
+	if contacts[0].Username != "example" || contacts[1].Username != "lid-example" {
+		t.Fatalf("usernames = %q, %q", contacts[0].Username, contacts[1].Username)
+	}
+}
+
+type recordingLIDContactStore struct {
+	store.NoopStore
+	jid      types.JID
+	fullName string
+	username string
+}
+
+func (contacts *recordingLIDContactStore) PutContactName(_ context.Context, jid types.JID, _, fullName string) error {
+	contacts.jid = jid
+	contacts.fullName = fullName
+	return nil
+}
+
+func (contacts *recordingLIDContactStore) PutContactUsername(_ context.Context, jid types.JID, username string) error {
+	contacts.jid = jid
+	contacts.username = username
+	return nil
+}
+
+func TestDispatchLIDContactPersistsNamesAndUsername(t *testing.T) {
+	contacts := &recordingLIDContactStore{}
+	client := &Client{Store: &store.Device{Contacts: contacts}}
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	client.dispatchAppState(context.Background(), appstate.WAPatchCriticalUnblockLow, appstate.Mutation{
+		Index: []string{appstate.IndexLIDContact, lid.String()},
+		Action: &waSyncAction.SyncActionValue{LidContactAction: &waSyncAction.LidContactAction{
+			FullName: proto.String("LID User"), Username: proto.String("lid-example"),
+		}},
+	}, false)
+	if contacts.jid != lid || contacts.fullName != "LID User" || contacts.username != "lid-example" {
+		t.Fatalf("unexpected persisted contact: %#v", contacts)
 	}
 }

--- a/username_contact_test.go
+++ b/username_contact_test.go
@@ -10,6 +10,7 @@ import (
 	"go.mau.fi/whatsmeow/proto/waSyncAction"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
 )
 
 func TestFilterContactsPreservesUsername(t *testing.T) {
@@ -61,7 +62,7 @@ func TestDispatchLIDContactPersistsNamesAndUsername(t *testing.T) {
 	contacts := &recordingLIDContactStore{}
 	client := &Client{Store: &store.Device{Contacts: contacts}}
 	lid := types.NewJID("100000011111111", types.HiddenUserServer)
-	client.dispatchAppState(context.Background(), appstate.WAPatchCriticalUnblockLow, appstate.Mutation{
+	event := client.dispatchAppState(context.Background(), appstate.WAPatchCriticalUnblockLow, appstate.Mutation{
 		Index: []string{appstate.IndexLIDContact, lid.String()},
 		Action: &waSyncAction.SyncActionValue{LidContactAction: &waSyncAction.LidContactAction{
 			FullName: proto.String("LID User"), Username: proto.String("lid-example"),
@@ -69,5 +70,9 @@ func TestDispatchLIDContactPersistsNamesAndUsername(t *testing.T) {
 	}, false)
 	if contacts.jid != lid || contacts.fullName != "LID User" || contacts.username != "lid-example" {
 		t.Fatalf("unexpected persisted contact: %#v", contacts)
+	}
+	lidEvent, ok := event.(*events.LIDContact)
+	if !ok || lidEvent.JID != lid || lidEvent.Action.GetUsername() != "lid-example" {
+		t.Fatalf("unexpected LID contact event: %#v", event)
 	}
 }

--- a/username_resolution_test.go
+++ b/username_resolution_test.go
@@ -1,0 +1,59 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestParseUsernameResolution(t *testing.T) {
+	list := &waBinary.Node{Tag: "list", Content: []waBinary.Node{{
+		Tag:   "user",
+		Attrs: waBinary.Attrs{"jid": types.NewJID("100000011111111", types.HiddenUserServer)},
+		Content: []waBinary.Node{{
+			Tag:   "contact",
+			Attrs: waBinary.Attrs{"type": "in", "username": "example"},
+		}},
+	}}}
+	result, err := parseUsernameResolution(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.LID.String() != "100000011111111@lid" || result.Username != "example" || result.KeyRequired {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestParseUsernameResolutionDetectsRequiredKey(t *testing.T) {
+	list := &waBinary.Node{Tag: "list", Content: []waBinary.Node{{
+		Tag: "user",
+		Content: []waBinary.Node{{
+			Tag:   "contact",
+			Attrs: waBinary.Attrs{"type": "in"},
+		}},
+	}}}
+	result, err := parseUsernameResolution(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.KeyRequired {
+		t.Fatal("expected username key requirement")
+	}
+}
+
+func TestHistoricalInlineContactsPreferLID(t *testing.T) {
+	entries, mappings := historicalInlineContactEntries([]*waHistorySync.InlineContact{{
+		PnJID:    stringPtr("15550001111@s.whatsapp.net"),
+		LidJID:   stringPtr("100000011111111@lid"),
+		FullName: stringPtr("Example User"),
+		Username: stringPtr("example"),
+	}})
+	if len(entries) != 1 || entries[0].JID.String() != "100000011111111@lid" || entries[0].Username != "example" {
+		t.Fatalf("unexpected entries: %+v", entries)
+	}
+	if len(mappings) != 1 || mappings[0].LID != entries[0].JID {
+		t.Fatalf("unexpected mappings: %+v", mappings)
+	}
+}


### PR DESCRIPTION
## What

Indexes Signal identities by LID and adds username-to-LID USync resolution.

## Why

LID is always available and remains stable when a phone number is hidden or a username changes. Using it as the cryptographic identity prevents duplicate user/session records split across PN, username, and LID.

## Impact

Phone numbers and usernames remain aliases when known. Existing callers can retain those fields without using them as primary identity keys.

## Checks

- `go test ./...`
- `go vet ./...`

