### PR TITLE
codex/username alias persistence

### DIFF
--- a/group.go
+++ b/group.go
@@ -273,14 +273,24 @@ func (cli *Client) GetGroupRequestParticipants(ctx context.Context, jid types.JI
 		return nil, &ElementMissingError{Tag: "membership_approval_requests", In: "response to group request participants query"}
 	}
 	requestParticipants := request.GetChildrenByTag("membership_approval_request")
-	participants := make([]types.GroupParticipantRequest, len(requestParticipants))
-	for i, req := range requestParticipants {
-		participants[i] = types.GroupParticipantRequest{
-			JID:         req.AttrGetter().JID("jid"),
-			RequestedAt: req.AttrGetter().UnixTime("request_time"),
-		}
-	}
+	participants, usernames := parseGroupParticipantRequests(requestParticipants)
+	cli.storeContactUsernamesBestEffort(ctx, usernames)
 	return participants, nil
+}
+
+func parseGroupParticipantRequests(nodes []waBinary.Node) ([]types.GroupParticipantRequest, []store.ContactUsernameEntry) {
+	participants := make([]types.GroupParticipantRequest, len(nodes))
+	usernames := make([]store.ContactUsernameEntry, 0, len(nodes))
+	for i := range nodes {
+		ag := nodes[i].AttrGetter()
+		participant := parseParticipant(ag, &nodes[i])
+		participants[i] = types.GroupParticipantRequest{
+			JID:         participant.JID,
+			RequestedAt: ag.UnixTime("request_time"),
+		}
+		usernames = append(usernames, groupParticipantUsernames([]types.GroupParticipant{participant})...)
+	}
+	return participants, usernames
 }
 
 type ParticipantRequestChange string

--- a/group.go
+++ b/group.go
@@ -157,7 +157,7 @@ func (cli *Client) CreateGroup(ctx context.Context, req ReqCreateGroup) (*types.
 	if !ok {
 		return nil, &ElementMissingError{Tag: "group", In: "response to create group query"}
 	}
-	return cli.parseGroupNode(&groupNode)
+	return cli.parseGroupNodeAndStoreUsernames(ctx, &groupNode)
 }
 
 // UnlinkGroup removes a child group from a parent community.
@@ -474,7 +474,7 @@ func (cli *Client) GetGroupInfoFromInvite(ctx context.Context, jid, inviter type
 	if !ok {
 		return nil, &ElementMissingError{Tag: "group", In: "response to invite group info query"}
 	}
-	return cli.parseGroupNode(&groupNode)
+	return cli.parseGroupNodeAndStoreUsernames(ctx, &groupNode)
 }
 
 // JoinGroupWithInvite joins a group using an invite message.
@@ -512,7 +512,7 @@ func (cli *Client) GetGroupInfoFromLink(ctx context.Context, code string) (*type
 	if !ok {
 		return nil, &ElementMissingError{Tag: "group", In: "response to group link info query"}
 	}
-	return cli.parseGroupNode(&groupNode)
+	return cli.parseGroupNodeAndStoreUsernames(ctx, &groupNode)
 }
 
 // JoinGroupWithLink joins the group using the given invite link.
@@ -672,6 +672,15 @@ func (cli *Client) cacheGroupInfo(groupInfo *types.GroupInfo, lock bool) ([]stor
 
 func groupContactUsernames(groupInfo *types.GroupInfo) []store.ContactUsernameEntry {
 	return groupParticipantUsernames(groupInfo.Participants)
+}
+
+func (cli *Client) parseGroupNodeAndStoreUsernames(ctx context.Context, groupNode *waBinary.Node) (*types.GroupInfo, error) {
+	groupInfo, err := cli.parseGroupNode(groupNode)
+	if err != nil {
+		return groupInfo, err
+	}
+	cli.storeContactUsernamesBestEffort(ctx, groupContactUsernames(groupInfo))
+	return groupInfo, nil
 }
 
 func groupParticipantUsernames(participants []types.GroupParticipant) []store.ContactUsernameEntry {

--- a/group.go
+++ b/group.go
@@ -624,13 +624,14 @@ func (cli *Client) GetLinkedGroupsParticipants(ctx context.Context, community ty
 	if !ok {
 		return nil, &ElementMissingError{Tag: "linked_groups_participants", In: "response to community participants query"}
 	}
-	members, lidPairs, _ := parseParticipantList(&participants)
+	members, lidPairs, usernames := parseParticipantList(&participants)
 	if len(lidPairs) > 0 {
 		err = cli.Store.LIDs.PutManyLIDMappings(ctx, lidPairs)
 		if err != nil {
 			cli.Log.Warnf("Failed to store LID mappings for community participants: %v", err)
 		}
 	}
+	cli.storeContactUsernamesBestEffort(ctx, usernames)
 	return members, nil
 }
 

--- a/group.go
+++ b/group.go
@@ -624,7 +624,7 @@ func (cli *Client) GetLinkedGroupsParticipants(ctx context.Context, community ty
 	if !ok {
 		return nil, &ElementMissingError{Tag: "linked_groups_participants", In: "response to community participants query"}
 	}
-	members, lidPairs := parseParticipantList(&participants)
+	members, lidPairs, _ := parseParticipantList(&participants)
 	if len(lidPairs) > 0 {
 		err = cli.Store.LIDs.PutManyLIDMappings(ctx, lidPairs)
 		if err != nil {
@@ -867,7 +867,7 @@ func parseGroupLinkTargetNode(groupNode *waBinary.Node) (types.GroupLinkTarget, 
 	}, ag.Error()
 }
 
-func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPairs []store.LIDMapping) {
+func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPairs []store.LIDMapping, usernames []store.ContactUsernameEntry) {
 	children := node.GetChildren()
 	participants = make([]types.JID, 0, len(children))
 	for _, child := range children {
@@ -876,6 +876,8 @@ func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPai
 			continue
 		}
 		participants = append(participants, jid)
+		participant := parseParticipant(child.AttrGetter(), &child)
+		usernames = append(usernames, groupParticipantUsernames([]types.GroupParticipant{participant})...)
 		if jid.Server == types.HiddenUserServer {
 			phoneNumber, ok := child.Attrs["phone_number"].(types.JID)
 			if ok && !phoneNumber.IsEmpty() {
@@ -923,7 +925,7 @@ func (cli *Client) parseGroupCreate(parentNode, node *waBinary.Node) (*events.Jo
 	return &evt, lidPairs, redactedPhones, nil
 }
 
-func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []store.LIDMapping, error) {
+func (cli *Client) parseGroupChangeWithUsernames(node *waBinary.Node) (*events.GroupInfo, []store.LIDMapping, []store.ContactUsernameEntry, error) {
 	var evt events.GroupInfo
 	ag := node.AttrGetter()
 	evt.JID = ag.JID("from")
@@ -932,10 +934,11 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 	evt.SenderPN = ag.OptionalJID("participant_pn")
 	evt.Timestamp = ag.UnixTime("t")
 	if !ag.OK() {
-		return nil, nil, fmt.Errorf("group change doesn't contain required attributes: %w", ag.Error())
+		return nil, nil, nil, fmt.Errorf("group change doesn't contain required attributes: %w", ag.Error())
 	}
 
 	var lidPairs []store.LIDMapping
+	var usernames []store.ContactUsernameEntry
 	for _, child := range node.GetChildren() {
 		cag := child.AttrGetter()
 		if child.Tag == "add" || child.Tag == "remove" || child.Tag == "promote" || child.Tag == "demote" {
@@ -945,13 +948,25 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 		switch child.Tag {
 		case "add":
 			evt.JoinReason = cag.OptionalString("reason")
-			evt.Join, lidPairs = parseParticipantList(&child)
+			participants, pairs, names := parseParticipantList(&child)
+			evt.Join = participants
+			lidPairs = append(lidPairs, pairs...)
+			usernames = append(usernames, names...)
 		case "remove":
-			evt.Leave, lidPairs = parseParticipantList(&child)
+			participants, pairs, names := parseParticipantList(&child)
+			evt.Leave = participants
+			lidPairs = append(lidPairs, pairs...)
+			usernames = append(usernames, names...)
 		case "promote":
-			evt.Promote, lidPairs = parseParticipantList(&child)
+			participants, pairs, names := parseParticipantList(&child)
+			evt.Promote = participants
+			lidPairs = append(lidPairs, pairs...)
+			usernames = append(usernames, names...)
 		case "demote":
-			evt.Demote, lidPairs = parseParticipantList(&child)
+			participants, pairs, names := parseParticipantList(&child)
+			evt.Demote = participants
+			lidPairs = append(lidPairs, pairs...)
+			usernames = append(usernames, names...)
 		case "locked":
 			evt.Locked = &types.GroupLocked{IsLocked: true}
 		case "unlocked":
@@ -972,7 +987,7 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 				topicChild := child.GetChildByTag("body")
 				topicBytes, ok := topicChild.Content.([]byte)
 				if !ok {
-					return nil, nil, fmt.Errorf("group change description has unexpected body: %s", &topicChild)
+					return nil, nil, nil, fmt.Errorf("group change description has unexpected body: %s", &topicChild)
 				}
 				topicStr = string(topicBytes)
 			}
@@ -1014,12 +1029,12 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			}
 			groupNode, ok := child.GetOptionalChildByTag("group")
 			if !ok {
-				return nil, nil, &ElementMissingError{Tag: "group", In: "group link"}
+				return nil, nil, nil, &ElementMissingError{Tag: "group", In: "group link"}
 			}
 			var err error
 			evt.Link.Group, err = parseGroupLinkTargetNode(&groupNode)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse group link node in group change: %w", err)
+				return nil, nil, nil, fmt.Errorf("failed to parse group link node in group change: %w", err)
 			}
 		case "unlink":
 			evt.Unlink = &types.GroupLinkChange{
@@ -1028,12 +1043,12 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			}
 			groupNode, ok := child.GetOptionalChildByTag("group")
 			if !ok {
-				return nil, nil, &ElementMissingError{Tag: "group", In: "group unlink"}
+				return nil, nil, nil, &ElementMissingError{Tag: "group", In: "group unlink"}
 			}
 			var err error
 			evt.Unlink.Group, err = parseGroupLinkTargetNode(&groupNode)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse group unlink node in group change: %w", err)
+				return nil, nil, nil, fmt.Errorf("failed to parse group unlink node in group change: %w", err)
 			}
 		case "membership_approval_mode":
 			evt.MembershipApprovalMode = &types.GroupMembershipApprovalMode{
@@ -1047,10 +1062,15 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			evt.UnknownChanges = append(evt.UnknownChanges, &child)
 		}
 		if !cag.OK() {
-			return nil, nil, fmt.Errorf("group change %s element doesn't contain required attributes: %w", child.Tag, cag.Error())
+			return nil, nil, nil, fmt.Errorf("group change %s element doesn't contain required attributes: %w", child.Tag, cag.Error())
 		}
 	}
-	return &evt, lidPairs, nil
+	return &evt, lidPairs, usernames, nil
+}
+
+func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []store.LIDMapping, error) {
+	event, lidPairs, _, err := cli.parseGroupChangeWithUsernames(node)
+	return event, lidPairs, err
 }
 
 func (cli *Client) updateGroupParticipantCache(evt *events.GroupInfo) {
@@ -1084,18 +1104,27 @@ Outer:
 	}
 }
 
-func (cli *Client) parseGroupNotification(node *waBinary.Node) (any, []store.LIDMapping, []store.RedactedPhoneEntry, error) {
+func (cli *Client) parseGroupNotificationWithUsernames(node *waBinary.Node) (any, []store.LIDMapping, []store.RedactedPhoneEntry, []store.ContactUsernameEntry, error) {
 	children := node.GetChildren()
 	if len(children) == 1 && children[0].Tag == "create" {
-		return cli.parseGroupCreate(node, &children[0])
-	} else {
-		groupChange, lidPairs, err := cli.parseGroupChange(node)
+		event, lidPairs, redactedPhones, err := cli.parseGroupCreate(node, &children[0])
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
+		}
+		return event, lidPairs, redactedPhones, groupContactUsernames(&event.GroupInfo), nil
+	} else {
+		groupChange, lidPairs, usernames, err := cli.parseGroupChangeWithUsernames(node)
+		if err != nil {
+			return nil, nil, nil, nil, err
 		}
 		cli.updateGroupParticipantCache(groupChange)
-		return groupChange, lidPairs, nil, nil
+		return groupChange, lidPairs, nil, usernames, nil
 	}
+}
+
+func (cli *Client) parseGroupNotification(node *waBinary.Node) (any, []store.LIDMapping, []store.RedactedPhoneEntry, error) {
+	event, lidPairs, redactedPhones, _, err := cli.parseGroupNotificationWithUsernames(node)
+	return event, lidPairs, redactedPhones, err
 }
 
 // SetGroupJoinApprovalMode sets the group join approval mode to 'on' or 'off'.

--- a/group.go
+++ b/group.go
@@ -256,6 +256,7 @@ func (cli *Client) UpdateGroupParticipants(ctx context.Context, jid types.JID, p
 	for i, child := range requestParticipants {
 		participants[i] = parseParticipant(child.AttrGetter(), &child)
 	}
+	cli.storeContactUsernamesBestEffort(ctx, groupParticipantUsernames(participants))
 	return participants, nil
 }
 
@@ -321,6 +322,7 @@ func (cli *Client) UpdateGroupRequestParticipants(ctx context.Context, jid types
 	for i, child := range requestParticipants {
 		participants[i] = parseParticipant(child.AttrGetter(), &child)
 	}
+	cli.storeContactUsernamesBestEffort(ctx, groupParticipantUsernames(participants))
 	return participants, nil
 }
 
@@ -669,8 +671,12 @@ func (cli *Client) cacheGroupInfo(groupInfo *types.GroupInfo, lock bool) ([]stor
 }
 
 func groupContactUsernames(groupInfo *types.GroupInfo) []store.ContactUsernameEntry {
-	entries := make([]store.ContactUsernameEntry, 0, len(groupInfo.Participants))
-	for _, participant := range groupInfo.Participants {
+	return groupParticipantUsernames(groupInfo.Participants)
+}
+
+func groupParticipantUsernames(participants []types.GroupParticipant) []store.ContactUsernameEntry {
+	entries := make([]store.ContactUsernameEntry, 0, len(participants))
+	for _, participant := range participants {
 		if participant.Username == "" {
 			continue
 		}

--- a/group.go
+++ b/group.go
@@ -559,6 +559,7 @@ func (cli *Client) GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, err
 	infos := make([]*types.GroupInfo, 0, len(children))
 	var allLIDPairs []store.LIDMapping
 	var allRedactedPhones []store.RedactedPhoneEntry
+	var allUsernames []store.ContactUsernameEntry
 	for _, child := range children {
 		if child.Tag != "group" {
 			cli.Log.Debugf("Unexpected child in group list response: %s", &child)
@@ -571,6 +572,7 @@ func (cli *Client) GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, err
 		lidPairs, redactedPhones := cli.cacheGroupInfo(parsed, true)
 		allLIDPairs = append(allLIDPairs, lidPairs...)
 		allRedactedPhones = append(allRedactedPhones, redactedPhones...)
+		allUsernames = append(allUsernames, groupContactUsernames(parsed)...)
 		infos = append(infos, parsed)
 	}
 	err = cli.Store.LIDs.PutManyLIDMappings(ctx, allLIDPairs)
@@ -580,6 +582,9 @@ func (cli *Client) GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, err
 	err = cli.Store.Contacts.PutManyRedactedPhones(ctx, allRedactedPhones)
 	if err != nil {
 		cli.Log.Warnf("Failed to store redacted phones from joined groups: %v", err)
+	}
+	if err = putContactUsernames(ctx, cli.Store.Contacts, allUsernames); err != nil {
+		cli.Log.Warnf("Failed to store usernames from joined groups: %v", err)
 	}
 	return infos, nil
 }
@@ -663,6 +668,23 @@ func (cli *Client) cacheGroupInfo(groupInfo *types.GroupInfo, lock bool) ([]stor
 	return lidPairs, redactedPhones
 }
 
+func groupContactUsernames(groupInfo *types.GroupInfo) []store.ContactUsernameEntry {
+	entries := make([]store.ContactUsernameEntry, 0, len(groupInfo.Participants))
+	for _, participant := range groupInfo.Participants {
+		if participant.Username == "" {
+			continue
+		}
+		lid := participant.LID.ToNonAD()
+		if lid.IsEmpty() && participant.JID.Server == types.HiddenUserServer {
+			lid = participant.JID.ToNonAD()
+		}
+		if !lid.IsEmpty() {
+			entries = append(entries, store.ContactUsernameEntry{JID: lid, Username: participant.Username})
+		}
+	}
+	return entries
+}
+
 func (cli *Client) getGroupInfo(ctx context.Context, jid types.JID, lockParticipantCache bool) (*types.GroupInfo, error) {
 	res, err := cli.sendGroupIQ(ctx, iqGet, jid, waBinary.Node{
 		Tag:   "query",
@@ -692,6 +714,9 @@ func (cli *Client) getGroupInfo(ctx context.Context, jid types.JID, lockParticip
 	err = cli.Store.Contacts.PutManyRedactedPhones(ctx, redactedPhones)
 	if err != nil {
 		cli.Log.Warnf("Failed to store redacted phones for members of %s: %v", jid, err)
+	}
+	if err = putContactUsernames(ctx, cli.Store.Contacts, groupContactUsernames(groupInfo)); err != nil {
+		cli.Log.Warnf("Failed to store usernames for members of %s: %v", jid, err)
 	}
 	return groupInfo, nil
 }

--- a/group.go
+++ b/group.go
@@ -716,6 +716,7 @@ func parseParticipant(childAG *waBinary.AttrUtility, child *waBinary.Node) types
 		IsSuperAdmin: pcpType == "superadmin",
 		JID:          childAG.JID("jid"),
 		DisplayName:  childAG.OptionalString("display_name"),
+		Username:     childAG.OptionalString("username"),
 	}
 	if participant.JID.Server == types.HiddenUserServer {
 		participant.LID = participant.JID

--- a/group_username_test.go
+++ b/group_username_test.go
@@ -1,0 +1,20 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestParseGroupParticipantPreservesUsername(t *testing.T) {
+	node := &waBinary.Node{Tag: "participant", Attrs: waBinary.Attrs{
+		"jid":      types.NewJID("100000011111111", types.HiddenUserServer),
+		"username": "example",
+	}}
+	ag := node.AttrGetter()
+	participant := parseParticipant(ag, node)
+	if participant.Username != "example" {
+		t.Fatalf("username = %q", participant.Username)
+	}
+}

--- a/notification.go
+++ b/notification.go
@@ -476,7 +476,7 @@ func (cli *Client) handleNotification(ctx context.Context, node *waBinary.Node) 
 	case "fbid:devices":
 		cli.handleFBDeviceNotification(ctx, node)
 	case "w:gp2":
-		evt, lidPairs, redactedPhones, err := cli.parseGroupNotification(node)
+		evt, lidPairs, redactedPhones, usernames, err := cli.parseGroupNotificationWithUsernames(node)
 		if err != nil {
 			cli.Log.Errorf("Failed to parse group notification: %v", err)
 		} else {
@@ -488,9 +488,7 @@ func (cli *Client) handleNotification(ctx context.Context, node *waBinary.Node) 
 			if err != nil {
 				cli.Log.Warnf("Failed to store redacted phones from group notification: %v", err)
 			}
-			if joined, ok := evt.(*events.JoinedGroup); ok {
-				cli.storeContactUsernamesBestEffort(ctx, groupContactUsernames(&joined.GroupInfo))
-			}
+			cli.storeContactUsernamesBestEffort(ctx, usernames)
 			cancelled = cli.dispatchEvent(evt)
 		}
 	case "picture":

--- a/notification.go
+++ b/notification.go
@@ -488,6 +488,9 @@ func (cli *Client) handleNotification(ctx context.Context, node *waBinary.Node) 
 			if err != nil {
 				cli.Log.Warnf("Failed to store redacted phones from group notification: %v", err)
 			}
+			if joined, ok := evt.(*events.JoinedGroup); ok {
+				cli.storeContactUsernamesBestEffort(ctx, groupContactUsernames(&joined.GroupInfo))
+			}
 			cancelled = cli.dispatchEvent(evt)
 		}
 	case "picture":

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1010,6 +1010,8 @@ func (s *SQLStore) PutManyContactUsernames(ctx context.Context, entries []store.
 	entries = exslices.DeduplicateUnsortedOverwriteFunc(entries, func(entry store.ContactUsernameEntry) types.JID {
 		return entry.JID
 	})
+	s.contactCacheLock.Lock()
+	defer s.contactCacheLock.Unlock()
 	if err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
 		for batch := range slices.Chunk(entries, contactBatchSize) {
 			query, vars := putContactUsernamesMassInsertBuilder.Build([1]any{s.JID}, batch)
@@ -1021,14 +1023,12 @@ func (s *SQLStore) PutManyContactUsernames(ctx context.Context, entries []store.
 	}); err != nil {
 		return err
 	}
-	s.contactCacheLock.Lock()
 	for _, entry := range entries {
 		if cached, ok := s.contactCache[entry.JID]; ok {
 			cached.Username = entry.Username
 			cached.Found = true
 		}
 	}
-	s.contactCacheLock.Unlock()
 	return nil
 }
 

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -915,6 +915,10 @@ func splitContactNameEntries(contacts []store.ContactEntry) ([]store.ContactEntr
 	return withUsername, withoutUsername
 }
 
+var putContactUsernamesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.ContactUsernameEntry, [1]any](
+	putContactUsernameQuery, "($1, $%d, $%d)",
+)
+
 var putRedactedPhonesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.RedactedPhoneEntry, [1]any](
 	putRedactedPhoneQuery, "($1, $%d, $%d)",
 )
@@ -996,6 +1000,35 @@ func (s *SQLStore) PutContactUsername(ctx context.Context, user types.JID, usern
 		cached.Username = username
 		cached.Found = true
 	}
+	return nil
+}
+
+func (s *SQLStore) PutManyContactUsernames(ctx context.Context, entries []store.ContactUsernameEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	entries = exslices.DeduplicateUnsortedOverwriteFunc(entries, func(entry store.ContactUsernameEntry) types.JID {
+		return entry.JID
+	})
+	if err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
+		for batch := range slices.Chunk(entries, contactBatchSize) {
+			query, vars := putContactUsernamesMassInsertBuilder.Build([1]any{s.JID}, batch)
+			if _, err := s.db.Exec(ctx, query, vars...); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	s.contactCacheLock.Lock()
+	for _, entry := range entries {
+		if cached, ok := s.contactCache[entry.JID]; ok {
+			cached.Username = entry.Username
+			cached.Found = true
+		}
+	}
+	s.contactCacheLock.Unlock()
 	return nil
 }
 

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1007,9 +1007,7 @@ func (s *SQLStore) PutManyContactUsernames(ctx context.Context, entries []store.
 	if len(entries) == 0 {
 		return nil
 	}
-	entries = exslices.DeduplicateUnsortedOverwriteFunc(entries, func(entry store.ContactUsernameEntry) types.JID {
-		return entry.JID
-	})
+	entries = deduplicateContactUsernamesLastWriteWins(entries)
 	s.contactCacheLock.Lock()
 	defer s.contactCacheLock.Unlock()
 	if err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
@@ -1030,6 +1028,21 @@ func (s *SQLStore) PutManyContactUsernames(ctx context.Context, entries []store.
 		}
 	}
 	return nil
+}
+
+func deduplicateContactUsernamesLastWriteWins(entries []store.ContactUsernameEntry) []store.ContactUsernameEntry {
+	positions := make(map[types.JID]int, len(entries))
+	out := entries[:0]
+	for _, entry := range entries {
+		if position, ok := positions[entry.JID]; ok {
+			out[position] = entry
+		} else {
+			positions[entry.JID] = len(out)
+			out = append(out, entry)
+		}
+	}
+	clear(entries[len(out):])
+	return out
 }
 
 const contactBatchSize = 300

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -69,6 +70,44 @@ func (r *pnMigrationTestRows) Next(values []driver.Value) error {
 	return nil
 }
 
+type contactUsernameRaceDB struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+type contactUsernameRaceConnector struct{ state *contactUsernameRaceDB }
+
+func (connector *contactUsernameRaceConnector) Connect(context.Context) (driver.Conn, error) {
+	return &contactUsernameRaceConn{state: connector.state}, nil
+}
+
+func (*contactUsernameRaceConnector) Driver() driver.Driver { return pnMigrationTestDriver{} }
+
+type contactUsernameRaceConn struct{ state *contactUsernameRaceDB }
+
+func (*contactUsernameRaceConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("unexpected prepare")
+}
+
+func (*contactUsernameRaceConn) Close() error { return nil }
+func (*contactUsernameRaceConn) Begin() (driver.Tx, error) {
+	return contactUsernameRaceTx{}, nil
+}
+
+func (conn *contactUsernameRaceConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	conn.state.once.Do(func() {
+		close(conn.state.entered)
+		<-conn.state.release
+	})
+	return driver.RowsAffected(1), nil
+}
+
+type contactUsernameRaceTx struct{}
+
+func (contactUsernameRaceTx) Commit() error   { return nil }
+func (contactUsernameRaceTx) Rollback() error { return nil }
+
 func TestNewSQLStoreDefersCaches(t *testing.T) {
 	store := NewSQLStore(nil, types.JID{User: "123", Server: types.DefaultUserServer})
 	if store.contactCache != nil || store.identityCache != nil || store.migratedPNSessionsCache != nil || store.emptyPNMigrationCache != nil || store.migratingPNSessions != nil {
@@ -127,6 +166,40 @@ func TestContactCacheIsBounded(t *testing.T) {
 	}
 	if _, ok := store.contactCache[newJID]; !ok {
 		t.Fatal("new contact was not cached")
+	}
+}
+
+func TestPutManyContactUsernamesSerializesSingleWrites(t *testing.T) {
+	state := &contactUsernameRaceDB{entered: make(chan struct{}), release: make(chan struct{})}
+	db := sql.OpenDB(&contactUsernameRaceConnector{state: state})
+	t.Cleanup(func() { _ = db.Close() })
+	jid := types.NewJID("100000011111111", types.HiddenUserServer)
+	sqlStore := NewSQLStore(NewWithDB(db, "postgres", nil), types.NewJID("15550000000", types.DefaultUserServer))
+	sqlStore.contactCache = map[types.JID]*types.ContactInfo{jid: {Found: true, Username: "initial"}}
+
+	batchDone := make(chan error, 1)
+	go func() {
+		batchDone <- sqlStore.PutManyContactUsernames(context.Background(), []store.ContactUsernameEntry{{JID: jid, Username: "batch"}})
+	}()
+	<-state.entered
+	singleDone := make(chan error, 1)
+	go func() {
+		singleDone <- sqlStore.PutContactUsername(context.Background(), jid, "single")
+	}()
+	select {
+	case err := <-singleDone:
+		t.Fatalf("single write overtook batch write: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(state.release)
+	if err := <-batchDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-singleDone; err != nil {
+		t.Fatal(err)
+	}
+	if got := sqlStore.contactCache[jid].Username; got != "single" {
+		t.Fatalf("cached username = %q, want single", got)
 	}
 }
 

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -203,6 +203,25 @@ func TestPutManyContactUsernamesSerializesSingleWrites(t *testing.T) {
 	}
 }
 
+func TestDeduplicateContactUsernamesUsesLastAlias(t *testing.T) {
+	firstJID := types.NewJID("100000011111111", types.HiddenUserServer)
+	secondJID := types.NewJID("100000022222222", types.HiddenUserServer)
+	entries := deduplicateContactUsernamesLastWriteWins([]store.ContactUsernameEntry{
+		{JID: firstJID, Username: "old"},
+		{JID: secondJID, Username: "other"},
+		{JID: firstJID, Username: "new"},
+	})
+	if len(entries) != 2 {
+		t.Fatalf("deduplicated entries = %#v", entries)
+	}
+	if entries[0].JID != firstJID || entries[0].Username != "new" {
+		t.Fatalf("first entry = %#v, want latest alias for %s", entries[0], firstJID)
+	}
+	if entries[1].JID != secondJID || entries[1].Username != "other" {
+		t.Fatalf("second entry = %#v", entries[1])
+	}
+}
+
 func TestMigratePNToLIDCachesEmptyPreflightTemporarily(t *testing.T) {
 	state := &pnMigrationTestDB{}
 	db := sql.OpenDB(&pnMigrationTestConnector{state: state})

--- a/store/store.go
+++ b/store/store.go
@@ -114,6 +114,16 @@ type ContactStore interface {
 
 type ContactUsernameStore interface {
 	PutContactUsername(ctx context.Context, user types.JID, username string) error
+	PutManyContactUsernames(ctx context.Context, entries []ContactUsernameEntry) error
+}
+
+type ContactUsernameEntry struct {
+	JID      types.JID
+	Username string
+}
+
+func (cue ContactUsernameEntry) GetMassInsertValues() [2]any {
+	return [...]any{cue.JID.String(), cue.Username}
 }
 
 var MutedForever = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)

--- a/store/store.go
+++ b/store/store.go
@@ -114,6 +114,9 @@ type ContactStore interface {
 
 type ContactUsernameStore interface {
 	PutContactUsername(ctx context.Context, user types.JID, username string) error
+}
+
+type ContactUsernameBatchStore interface {
 	PutManyContactUsernames(ctx context.Context, entries []ContactUsernameEntry) error
 }
 

--- a/types/group.go
+++ b/types/group.go
@@ -106,6 +106,7 @@ type GroupParticipant struct {
 	JID         JID
 	PhoneNumber JID
 	LID         JID
+	Username    string
 
 	IsAdmin      bool
 	IsSuperAdmin bool

--- a/types/user.go
+++ b/types/user.go
@@ -99,6 +99,7 @@ type IsOnWhatsAppResponse struct {
 	IsIn  bool   // Whether the phone is registered or not.
 
 	PhoneNumber JID
+	Username    string
 
 	VerifiedName *VerifiedName // If the phone is a business, the verified business details.
 }

--- a/user.go
+++ b/user.go
@@ -230,10 +230,14 @@ func (cli *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.I
 			return output, fmt.Errorf("failed to store LID mappings: %w", err)
 		}
 	}
-	if err = putContactUsernames(ctx, cli.Store.Contacts, usernameEntries); err != nil {
-		return output, fmt.Errorf("failed to store usernames: %w", err)
-	}
+	cli.storeContactUsernamesBestEffort(ctx, usernameEntries)
 	return output, nil
+}
+
+func (cli *Client) storeContactUsernamesBestEffort(ctx context.Context, entries []store.ContactUsernameEntry) {
+	if err := putContactUsernames(ctx, cli.Store.Contacts, entries); err != nil {
+		cli.Log.Warnf("Failed to store usernames: %v", err)
+	}
 }
 
 func putContactUsernames(ctx context.Context, contacts store.ContactStore, entries []store.ContactUsernameEntry) error {

--- a/user.go
+++ b/user.go
@@ -230,12 +230,29 @@ func (cli *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.I
 			return output, fmt.Errorf("failed to store LID mappings: %w", err)
 		}
 	}
-	if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && len(usernameEntries) > 0 {
-		if err = usernameStore.PutManyContactUsernames(ctx, usernameEntries); err != nil {
-			return output, fmt.Errorf("failed to store usernames: %w", err)
-		}
+	if err = putContactUsernames(ctx, cli.Store.Contacts, usernameEntries); err != nil {
+		return output, fmt.Errorf("failed to store usernames: %w", err)
 	}
 	return output, nil
+}
+
+func putContactUsernames(ctx context.Context, contacts store.ContactStore, entries []store.ContactUsernameEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if batch, ok := contacts.(store.ContactUsernameBatchStore); ok {
+		return batch.PutManyContactUsernames(ctx, entries)
+	}
+	single, ok := contacts.(store.ContactUsernameStore)
+	if !ok {
+		return nil
+	}
+	for _, entry := range entries {
+		if err := single.PutContactUsername(ctx, entry.JID, entry.Username); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func parseUSyncUsername(user waBinary.Node) string {
@@ -305,10 +322,8 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 		// not worth returning on the error, instead just post a log
 		cli.Log.Errorf("Failed to place LID mappings from USync call")
 	}
-	if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && len(usernames) > 0 {
-		if err := usernameStore.PutManyContactUsernames(ctx, usernames); err != nil {
-			cli.Log.Errorf("Failed to store usernames from USync call: %v", err)
-		}
+	if err := putContactUsernames(ctx, cli.Store.Contacts, usernames); err != nil {
+		cli.Log.Errorf("Failed to store usernames from USync call: %v", err)
 	}
 
 	return respData, nil

--- a/user.go
+++ b/user.go
@@ -189,6 +189,7 @@ func (cli *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.I
 	}
 	output := make([]types.IsOnWhatsAppResponse, 0, len(jids))
 	lidEntries := make([]store.LIDMapping, 0, len(jids))
+	usernameEntries := make([]store.ContactUsernameEntry, 0, len(jids))
 	querySuffix := "@" + types.LegacyUserServer
 	for _, child := range list.GetChildren() {
 		ag := child.AttrGetter()
@@ -215,6 +216,10 @@ func (cli *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.I
 		}
 		contactNode := child.GetChildByTag("contact")
 		info.IsIn = contactNode.AttrGetter().String("type") == "in"
+		info.Username = parseUSyncUsername(child)
+		if info.Username != "" && info.JID.Server == types.HiddenUserServer {
+			usernameEntries = append(usernameEntries, store.ContactUsernameEntry{JID: info.JID, Username: info.Username})
+		}
 		contactQuery, _ := contactNode.Content.([]byte)
 		info.Query = strings.TrimSuffix(string(contactQuery), querySuffix)
 		output = append(output, info)
@@ -225,7 +230,20 @@ func (cli *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.I
 			return output, fmt.Errorf("failed to store LID mappings: %w", err)
 		}
 	}
+	if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && len(usernameEntries) > 0 {
+		if err = usernameStore.PutManyContactUsernames(ctx, usernameEntries); err != nil {
+			return output, fmt.Errorf("failed to store usernames: %w", err)
+		}
+	}
 	return output, nil
+}
+
+func parseUSyncUsername(user waBinary.Node) string {
+	if username, ok := user.GetChildByTag("username").Content.([]byte); ok && len(username) > 0 {
+		return string(username)
+	}
+	contact := user.GetChildByTag("contact")
+	return contact.AttrGetter().OptionalString("username")
 }
 
 // GetUserInfo gets basic user info (avatar, status, verified business name, device list).
@@ -245,6 +263,7 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 	}
 	respData := make(map[types.JID]types.UserInfo, len(jids))
 	mappings := make([]store.LIDMapping, 0, len(jids))
+	usernames := make([]store.ContactUsernameEntry, 0, len(jids))
 	for _, child := range list.GetChildren() {
 		jid, jidOK := child.Attrs["jid"].(types.JID)
 		if child.Tag != "user" || !jidOK {
@@ -262,8 +281,7 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 
 		lidTag := child.GetChildByTag("lid")
 		info.LID = lidTag.AttrGetter().OptionalJIDOrEmpty("val")
-		username, _ := child.GetChildByTag("username").Content.([]byte)
-		info.Username = string(username)
+		info.Username = parseUSyncUsername(child)
 
 		if !info.LID.IsEmpty() {
 			mappings = append(mappings, store.LIDMapping{PN: jid, LID: info.LID})
@@ -273,14 +291,12 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 			cli.updateBusinessName(ctx, jid, info.LID, nil, verifiedName.Details.GetVerifiedName())
 		}
 		respData[jid] = info
-		if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && info.Username != "" {
+		if info.Username != "" {
 			usernameJID := info.LID
 			if usernameJID.IsEmpty() {
 				usernameJID = jid
 			}
-			if err := usernameStore.PutContactUsername(ctx, usernameJID, info.Username); err != nil {
-				cli.Log.Warnf("Failed to store username for %s: %v", usernameJID, err)
-			}
+			usernames = append(usernames, store.ContactUsernameEntry{JID: usernameJID, Username: info.Username})
 		}
 	}
 
@@ -288,6 +304,11 @@ func (cli *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types
 	if err != nil {
 		// not worth returning on the error, instead just post a log
 		cli.Log.Errorf("Failed to place LID mappings from USync call")
+	}
+	if usernameStore, ok := cli.Store.Contacts.(store.ContactUsernameStore); ok && len(usernames) > 0 {
+		if err := usernameStore.PutManyContactUsernames(ctx, usernames); err != nil {
+			cli.Log.Errorf("Failed to store usernames from USync call: %v", err)
+		}
 	}
 
 	return respData, nil

--- a/user.go
+++ b/user.go
@@ -251,12 +251,13 @@ func putContactUsernames(ctx context.Context, contacts store.ContactStore, entri
 	if !ok {
 		return nil
 	}
+	var firstErr error
 	for _, entry := range entries {
-		if err := single.PutContactUsername(ctx, entry.JID, entry.Username); err != nil {
-			return err
+		if err := single.PutContactUsername(ctx, entry.JID, entry.Username); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func parseUSyncUsername(user waBinary.Node) string {

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -77,3 +77,13 @@ func TestGroupContactUsernamesUseStableLIDs(t *testing.T) {
 		t.Fatalf("unexpected group username entries: %#v", entries)
 	}
 }
+
+func TestGroupParticipantUsernamesUseStableLIDs(t *testing.T) {
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	entries := groupParticipantUsernames([]types.GroupParticipant{{
+		JID: types.NewJID("15550001111", types.DefaultUserServer), LID: lid, Username: "example",
+	}})
+	if len(entries) != 1 || entries[0].JID != lid || entries[0].Username != "example" {
+		t.Fatalf("unexpected participant username entries: %#v", entries)
+	}
+}

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -2,15 +2,27 @@ package whatsmeow
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 type singleUsernameStore struct {
 	store.NoopStore
 	entries []store.ContactUsernameEntry
+}
+
+type failingUsernameStore struct {
+	store.NoopStore
+	called bool
+}
+
+func (failing *failingUsernameStore) PutContactUsername(context.Context, types.JID, string) error {
+	failing.called = true
+	return errors.New("synthetic username cache failure")
 }
 
 func (single *singleUsernameStore) PutContactUsername(_ context.Context, user types.JID, username string) error {
@@ -41,6 +53,17 @@ func TestPutContactUsernamesFallsBackToSingleWrites(t *testing.T) {
 		if contacts.entries[index] != entries[index] {
 			t.Fatalf("stored entry %d = %#v, want %#v", index, contacts.entries[index], entries[index])
 		}
+	}
+}
+
+func TestContactUsernamePersistenceIsBestEffort(t *testing.T) {
+	contacts := &failingUsernameStore{}
+	client := &Client{Store: &store.Device{Contacts: contacts}, Log: waLog.Noop}
+	client.storeContactUsernamesBestEffort(context.Background(), []store.ContactUsernameEntry{{
+		JID: types.NewJID("100000011111111", types.HiddenUserServer), Username: "example",
+	}})
+	if !contacts.called {
+		t.Fatal("username cache write was not attempted")
 	}
 }
 

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -162,3 +162,30 @@ func TestParseGroupChangeReturnsParticipantUsernames(t *testing.T) {
 		t.Fatalf("group-change usernames = %#v", usernames)
 	}
 }
+
+func TestParseGroupParticipantRequestsReturnsUsernamesByStableLID(t *testing.T) {
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	pn := types.NewJID("15550001111", types.DefaultUserServer)
+	nodes := []waBinary.Node{
+		{Tag: "membership_approval_request", Attrs: waBinary.Attrs{
+			"jid": lid, "username": "lid-user", "request_time": "1",
+		}},
+		{Tag: "membership_approval_request", Attrs: waBinary.Attrs{
+			"jid": pn, "lid": lid, "username": "pn-user", "request_time": "2",
+		}},
+	}
+
+	requests, usernames := parseGroupParticipantRequests(nodes)
+	if len(requests) != 2 || requests[0].JID != lid || requests[1].JID != pn {
+		t.Fatalf("participant requests = %#v", requests)
+	}
+	if len(usernames) != 2 {
+		t.Fatalf("usernames = %#v", usernames)
+	}
+	if usernames[0].JID != lid || usernames[0].Username != "lid-user" {
+		t.Fatalf("LID-addressed username = %#v", usernames[0])
+	}
+	if usernames[1].JID != lid || usernames[1].Username != "pn-user" {
+		t.Fatalf("PN-addressed username = %#v", usernames[1])
+	}
+}

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -140,3 +140,25 @@ func TestParseGroupResponsePersistsParticipantUsernames(t *testing.T) {
 		t.Fatalf("stored username = %#v", contacts.entries[0])
 	}
 }
+
+func TestParseGroupChangeReturnsParticipantUsernames(t *testing.T) {
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	node := &waBinary.Node{
+		Tag:   "notification",
+		Attrs: waBinary.Attrs{"from": types.NewJID("120363000000000000", types.GroupServer), "t": "1"},
+		Content: []waBinary.Node{{
+			Tag: "add",
+			Content: []waBinary.Node{{
+				Tag:   "participant",
+				Attrs: waBinary.Attrs{"jid": lid, "username": "example"},
+			}},
+		}},
+	}
+	_, _, usernames, err := (&Client{}).parseGroupChangeWithUsernames(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(usernames) != 1 || usernames[0].JID != lid || usernames[0].Username != "example" {
+		t.Fatalf("group-change usernames = %#v", usernames)
+	}
+}

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 	waLog "go.mau.fi/whatsmeow/util/log"
@@ -113,5 +114,29 @@ func TestGroupParticipantUsernamesUseStableLIDs(t *testing.T) {
 	}})
 	if len(entries) != 1 || entries[0].JID != lid || entries[0].Username != "example" {
 		t.Fatalf("unexpected participant username entries: %#v", entries)
+	}
+}
+
+func TestParseGroupResponsePersistsParticipantUsernames(t *testing.T) {
+	contacts := &singleUsernameStore{}
+	client := &Client{Store: &store.Device{Contacts: contacts}, Log: waLog.Noop}
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	groupNode := &waBinary.Node{
+		Tag:   "group",
+		Attrs: waBinary.Attrs{"id": "120363000000000000"},
+		Content: []waBinary.Node{{
+			Tag:   "participant",
+			Attrs: waBinary.Attrs{"jid": lid, "username": "example"},
+		}},
+	}
+	info, err := client.parseGroupNodeAndStoreUsernames(context.Background(), groupNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.Participants) != 1 || len(contacts.entries) != 1 {
+		t.Fatalf("parsed participants = %d, stored usernames = %#v", len(info.Participants), contacts.entries)
+	}
+	if contacts.entries[0].JID != lid || contacts.entries[0].Username != "example" {
+		t.Fatalf("stored username = %#v", contacts.entries[0])
 	}
 }

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -1,0 +1,56 @@
+package whatsmeow
+
+import (
+	"context"
+	"testing"
+
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type singleUsernameStore struct {
+	store.NoopStore
+	entries []store.ContactUsernameEntry
+}
+
+func (single *singleUsernameStore) PutContactUsername(_ context.Context, user types.JID, username string) error {
+	single.entries = append(single.entries, store.ContactUsernameEntry{JID: user, Username: username})
+	return nil
+}
+
+func TestContactUsernameStoreRemainsSingleWriteCompatible(t *testing.T) {
+	var contacts store.ContactStore = &singleUsernameStore{}
+	if _, ok := contacts.(store.ContactUsernameStore); !ok {
+		t.Fatal("single-write username store no longer satisfies ContactUsernameStore")
+	}
+}
+
+func TestPutContactUsernamesFallsBackToSingleWrites(t *testing.T) {
+	contacts := &singleUsernameStore{}
+	entries := []store.ContactUsernameEntry{
+		{JID: types.NewJID("100000011111111", types.HiddenUserServer), Username: "first"},
+		{JID: types.NewJID("100000022222222", types.HiddenUserServer), Username: "second"},
+	}
+	if err := putContactUsernames(context.Background(), contacts, entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(contacts.entries) != len(entries) {
+		t.Fatalf("stored %d usernames, want %d", len(contacts.entries), len(entries))
+	}
+	for index := range entries {
+		if contacts.entries[index] != entries[index] {
+			t.Fatalf("stored entry %d = %#v, want %#v", index, contacts.entries[index], entries[index])
+		}
+	}
+}
+
+func TestGroupContactUsernamesUseStableLIDs(t *testing.T) {
+	lid := types.NewJID("100000011111111", types.HiddenUserServer)
+	entries := groupContactUsernames(&types.GroupInfo{Participants: []types.GroupParticipant{
+		{JID: lid, LID: lid, Username: "example"},
+		{JID: types.NewJID("15550001111", types.DefaultUserServer), Username: "missing-lid"},
+	}})
+	if len(entries) != 1 || entries[0].JID != lid || entries[0].Username != "example" {
+		t.Fatalf("unexpected group username entries: %#v", entries)
+	}
+}

--- a/username_persistence_test.go
+++ b/username_persistence_test.go
@@ -20,6 +20,19 @@ type failingUsernameStore struct {
 	called bool
 }
 
+type partiallyFailingUsernameStore struct {
+	store.NoopStore
+	entries []store.ContactUsernameEntry
+}
+
+func (partial *partiallyFailingUsernameStore) PutContactUsername(_ context.Context, user types.JID, username string) error {
+	if username == "first" {
+		return errors.New("synthetic first-write failure")
+	}
+	partial.entries = append(partial.entries, store.ContactUsernameEntry{JID: user, Username: username})
+	return nil
+}
+
 func (failing *failingUsernameStore) PutContactUsername(context.Context, types.JID, string) error {
 	failing.called = true
 	return errors.New("synthetic username cache failure")
@@ -53,6 +66,21 @@ func TestPutContactUsernamesFallsBackToSingleWrites(t *testing.T) {
 		if contacts.entries[index] != entries[index] {
 			t.Fatalf("stored entry %d = %#v, want %#v", index, contacts.entries[index], entries[index])
 		}
+	}
+}
+
+func TestPutContactUsernamesContinuesAfterSingleWriteFailure(t *testing.T) {
+	contacts := &partiallyFailingUsernameStore{}
+	second := store.ContactUsernameEntry{JID: types.NewJID("100000022222222", types.HiddenUserServer), Username: "second"}
+	err := putContactUsernames(context.Background(), contacts, []store.ContactUsernameEntry{
+		{JID: types.NewJID("100000011111111", types.HiddenUserServer), Username: "first"},
+		second,
+	})
+	if err == nil {
+		t.Fatal("single-write failure was not returned")
+	}
+	if len(contacts.entries) != 1 || contacts.entries[0] != second {
+		t.Fatalf("writes after the first failure were skipped: %#v", contacts.entries)
 	}
 }
 

--- a/username_resolution_test.go
+++ b/username_resolution_test.go
@@ -26,6 +26,16 @@ func TestParseUsernameResolution(t *testing.T) {
 	}
 }
 
+func TestParseUSyncUsernameFallsBackToContactAttribute(t *testing.T) {
+	user := waBinary.Node{Tag: "user", Content: []waBinary.Node{{
+		Tag:   "contact",
+		Attrs: waBinary.Attrs{"username": "example"},
+	}}}
+	if got := parseUSyncUsername(user); got != "example" {
+		t.Fatalf("username = %q", got)
+	}
+}
+
 func TestParseUsernameResolutionDetectsRequiredKey(t *testing.T) {
 	list := &waBinary.Node{Tag: "list", Content: []waBinary.Node{{
 		Tag: "user",


### PR DESCRIPTION
## What

Persists username aliases and batches their updates across contact and group flows.

## Why

Username support must survive process restarts without adding a database write per message or creating a second user identity.

## Impact

Username remains an optional alias of the LID. The migration is additive and updates are batched.

## Checks

- `go test ./...`
- `go vet ./...`

