### PR TITLE
Batch reverse LID alias lookups

### DIFF
--- a/store/noop.go
+++ b/store/noop.go
@@ -281,6 +281,10 @@ func (n *NoopStore) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error) {
 	return types.JID{}, n.Error
 }

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -243,6 +243,65 @@ func (s *CachedLIDMap) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (
 	return result, err
 }
 
+func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
+	if len(lids) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[types.JID]types.JID, len(lids))
+
+	s.lidCacheLock.RLock()
+	missingLIDs := make([]string, 0, len(lids))
+	missingLIDDevices := make(map[string][]types.JID)
+	for _, lid := range lids {
+		if lid.Server != types.HiddenUserServer {
+			continue
+		}
+		if pnUser, ok := s.lidToPNCache[lid.User]; ok && pnUser != "" {
+			result[lid] = types.JID{User: pnUser, Device: lid.Device, Server: types.DefaultUserServer}
+		} else if !s.cacheFilled {
+			missingLIDs = append(missingLIDs, lid.User)
+			missingLIDDevices[lid.User] = append(missingLIDDevices[lid.User], lid)
+		}
+	}
+	s.lidCacheLock.RUnlock()
+
+	if len(missingLIDs) == 0 {
+		return result, nil
+	}
+
+	s.lidCacheLock.Lock()
+	defer s.lidCacheLock.Unlock()
+
+	var res dbutil.RowIter[store.LIDMapping]
+	if wrapped, ok := wrapPostgresArray(s.db, missingLIDs); ok {
+		res = convertLIDRow.NewRowIter(s.db.Query(
+			ctx,
+			`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid = ANY($1)`,
+			wrapped,
+		))
+	} else {
+		placeholders := make([]string, len(missingLIDs))
+		for i := range missingLIDs {
+			placeholders[i] = fmt.Sprintf("$%d", i+1)
+		}
+		res = convertLIDRow.NewRowIter(s.db.Query(
+			ctx,
+			fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
+			exslices.CastToAny(missingLIDs)...,
+		))
+	}
+	_, err := s.scanManyLids(res, func(lid, pn string) {
+		for _, dev := range missingLIDDevices[lid] {
+			pnDev := dev
+			pnDev.Server = types.DefaultUserServer
+			pnDev.User = pn
+			result[dev] = pnDev
+		}
+	})
+	return result, err
+}
+
 func (s *CachedLIDMap) PutLIDMapping(ctx context.Context, lid, pn types.JID) error {
 	if lid.Server != types.HiddenUserServer || pn.Server != types.DefaultUserServer {
 		return fmt.Errorf("invalid PutLIDMapping call %s/%s", lid, pn)

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -296,43 +296,51 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 		return result, nil
 	}
 
-	var res dbutil.RowIter[store.LIDMapping]
+	found := make(map[string]struct{}, len(missingLIDs))
+	scanResults := func(res dbutil.RowIter[store.LIDMapping]) error {
+		_, err := s.scanManyLids(res, func(lid, pn string) {
+			found[lid] = struct{}{}
+			for _, dev := range missingLIDDevices[lid] {
+				pnDev := dev
+				pnDev.Server = types.DefaultUserServer
+				pnDev.User = pn
+				result[dev] = pnDev
+			}
+		})
+		return err
+	}
 	if wrapped, ok := wrapPostgresArray(s.db, missingLIDs); ok {
-		res = convertLIDRow.NewRowIter(s.db.Query(
+		if err := scanResults(convertLIDRow.NewRowIter(s.db.Query(
 			ctx,
 			`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid = ANY($1)`,
 			wrapped,
-		))
+		))); err != nil {
+			return result, err
+		}
 	} else {
-		placeholders := make([]string, len(missingLIDs))
-		for i := range missingLIDs {
-			placeholders[i] = fmt.Sprintf("$%d", i+1)
-		}
-		res = convertLIDRow.NewRowIter(s.db.Query(
-			ctx,
-			fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
-			exslices.CastToAny(missingLIDs)...,
-		))
-	}
-	found := make(map[string]struct{}, len(missingLIDs))
-	_, err := s.scanManyLids(res, func(lid, pn string) {
-		found[lid] = struct{}{}
-		for _, dev := range missingLIDDevices[lid] {
-			pnDev := dev
-			pnDev.Server = types.DefaultUserServer
-			pnDev.User = pn
-			result[dev] = pnDev
-		}
-	})
-	if err == nil {
-		for _, lid := range missingLIDs {
-			if _, ok := found[lid]; !ok {
-				s.cacheMissLocked(s.lidToPNCache, s.pnToLIDCache, lid)
+		for lids := range slices.Chunk(missingLIDs, lidQueryBatchSize) {
+			placeholders := make([]string, len(lids))
+			for i := range lids {
+				placeholders[i] = fmt.Sprintf("$%d", i+1)
+			}
+			if err := scanResults(convertLIDRow.NewRowIter(s.db.Query(
+				ctx,
+				fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
+				exslices.CastToAny(lids)...,
+			))); err != nil {
+				return result, err
 			}
 		}
 	}
-	return result, err
+	for _, lid := range missingLIDs {
+		if _, ok := found[lid]; !ok {
+			s.cacheMissLocked(s.lidToPNCache, s.pnToLIDCache, lid)
+		}
+	}
+	return result, nil
 }
+
+const lidQueryBatchSize = 300
 
 func (s *CachedLIDMap) PutLIDMapping(ctx context.Context, lid, pn types.JID) error {
 	if lid.Server != types.HiddenUserServer || pn.Server != types.DefaultUserServer {

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -34,6 +34,7 @@ type CachedLIDMap struct {
 }
 
 var _ store.LIDStore = (*CachedLIDMap)(nil)
+var _ store.LIDBatchReverseStore = (*CachedLIDMap)(nil)
 
 const maxLIDCacheEntries = 65536
 
@@ -257,10 +258,16 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 		if lid.Server != types.HiddenUserServer {
 			continue
 		}
-		if pnUser, ok := s.lidToPNCache[lid.User]; ok && pnUser != "" {
-			result[lid] = types.JID{User: pnUser, Device: lid.Device, Server: types.DefaultUserServer}
-		} else if !s.cacheFilled {
-			missingLIDs = append(missingLIDs, lid.User)
+		if pnUser, ok := s.lidToPNCache[lid.User]; ok {
+			if pnUser != "" {
+				result[lid] = types.JID{User: pnUser, Device: lid.Device, Server: types.DefaultUserServer}
+			}
+			continue
+		}
+		if !s.cacheFilled {
+			if _, exists := missingLIDDevices[lid.User]; !exists {
+				missingLIDs = append(missingLIDs, lid.User)
+			}
 			missingLIDDevices[lid.User] = append(missingLIDDevices[lid.User], lid)
 		}
 	}
@@ -272,6 +279,22 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 
 	s.lidCacheLock.Lock()
 	defer s.lidCacheLock.Unlock()
+	queryLIDs := missingLIDs[:0]
+	for _, lid := range missingLIDs {
+		if pn, ok := s.lidToPNCache[lid]; ok {
+			if pn != "" {
+				for _, dev := range missingLIDDevices[lid] {
+					result[dev] = types.JID{User: pn, Device: dev.Device, Server: types.DefaultUserServer}
+				}
+			}
+		} else if !s.cacheFilled {
+			queryLIDs = append(queryLIDs, lid)
+		}
+	}
+	missingLIDs = queryLIDs
+	if len(missingLIDs) == 0 {
+		return result, nil
+	}
 
 	var res dbutil.RowIter[store.LIDMapping]
 	if wrapped, ok := wrapPostgresArray(s.db, missingLIDs); ok {
@@ -291,7 +314,9 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 			exslices.CastToAny(missingLIDs)...,
 		))
 	}
+	found := make(map[string]struct{}, len(missingLIDs))
 	_, err := s.scanManyLids(res, func(lid, pn string) {
+		found[lid] = struct{}{}
 		for _, dev := range missingLIDDevices[lid] {
 			pnDev := dev
 			pnDev.Server = types.DefaultUserServer
@@ -299,6 +324,13 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 			result[dev] = pnDev
 		}
 	})
+	if err == nil {
+		for _, lid := range missingLIDs {
+			if _, ok := found[lid]; !ok {
+				s.cacheMissLocked(s.lidToPNCache, s.pnToLIDCache, lid)
+			}
+		}
+	}
 	return result, err
 }
 

--- a/store/sqlstore/lidmap_test.go
+++ b/store/sqlstore/lidmap_test.go
@@ -12,7 +12,10 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
-type emptyLIDMapDB struct{ queries int }
+type emptyLIDMapDB struct {
+	queries int
+	maxArgs int
+}
 
 type emptyLIDMapConnector struct{ state *emptyLIDMapDB }
 
@@ -30,8 +33,9 @@ func (*emptyLIDMapConn) Prepare(string) (driver.Stmt, error) {
 
 func (*emptyLIDMapConn) Close() error              { return nil }
 func (*emptyLIDMapConn) Begin() (driver.Tx, error) { return nil, errors.New("unexpected transaction") }
-func (conn *emptyLIDMapConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+func (conn *emptyLIDMapConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
 	conn.state.queries++
+	conn.state.maxArgs = max(conn.state.maxArgs, len(args))
 	return emptyLIDMapRows{}, nil
 }
 
@@ -103,5 +107,26 @@ func TestGetManyPNsForLIDsCachesMissingMappings(t *testing.T) {
 	}
 	if state.queries != 1 {
 		t.Fatalf("missing mapping queried %d times, want 1", state.queries)
+	}
+}
+
+func TestGetManyPNsForLIDsChunksFallbackQueries(t *testing.T) {
+	state := &emptyLIDMapDB{}
+	db := sql.OpenDB(&emptyLIDMapConnector{state: state})
+	t.Cleanup(func() { _ = db.Close() })
+	cache := NewWithDB(db, "sqlite3", nil).LIDMap
+	lids := make([]types.JID, lidQueryBatchSize*2+1)
+	for i := range lids {
+		lids[i] = types.NewJID(fmt.Sprintf("%d", 100000000000000+i), types.HiddenUserServer)
+	}
+
+	if _, err := cache.GetManyPNsForLIDs(context.Background(), lids); err != nil {
+		t.Fatal(err)
+	}
+	if state.queries != 3 {
+		t.Fatalf("fallback issued %d queries, want 3", state.queries)
+	}
+	if state.maxArgs > lidQueryBatchSize {
+		t.Fatalf("fallback query used %d arguments, limit %d", state.maxArgs, lidQueryBatchSize)
 	}
 }

--- a/store/sqlstore/lidmap_test.go
+++ b/store/sqlstore/lidmap_test.go
@@ -2,11 +2,44 @@ package sqlstore
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"go.mau.fi/whatsmeow/types"
 )
+
+type emptyLIDMapDB struct{ queries int }
+
+type emptyLIDMapConnector struct{ state *emptyLIDMapDB }
+
+func (connector *emptyLIDMapConnector) Connect(context.Context) (driver.Conn, error) {
+	return &emptyLIDMapConn{state: connector.state}, nil
+}
+
+func (*emptyLIDMapConnector) Driver() driver.Driver { return pnMigrationTestDriver{} }
+
+type emptyLIDMapConn struct{ state *emptyLIDMapDB }
+
+func (*emptyLIDMapConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("unexpected prepare")
+}
+
+func (*emptyLIDMapConn) Close() error              { return nil }
+func (*emptyLIDMapConn) Begin() (driver.Tx, error) { return nil, errors.New("unexpected transaction") }
+func (conn *emptyLIDMapConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	conn.state.queries++
+	return emptyLIDMapRows{}, nil
+}
+
+type emptyLIDMapRows struct{}
+
+func (emptyLIDMapRows) Columns() []string         { return []string{"lid", "pn"} }
+func (emptyLIDMapRows) Close() error              { return nil }
+func (emptyLIDMapRows) Next([]driver.Value) error { return io.EOF }
 
 func TestLIDCacheIsBounded(t *testing.T) {
 	cache := NewCachedLIDMap(nil)
@@ -49,5 +82,26 @@ func TestGetManyPNsForLIDsUsesReverseCache(t *testing.T) {
 		if got[lid].String() != want {
 			t.Fatalf("phone for %s = %s, want %s", lid, got[lid], want)
 		}
+	}
+}
+
+func TestGetManyPNsForLIDsCachesMissingMappings(t *testing.T) {
+	state := &emptyLIDMapDB{}
+	db := sql.OpenDB(&emptyLIDMapConnector{state: state})
+	t.Cleanup(func() { _ = db.Close() })
+	cache := NewWithDB(db, "sqlite3", nil).LIDMap
+	lid := types.NewJID("100000000000001", types.HiddenUserServer)
+
+	for range 2 {
+		got, err := cache.GetManyPNsForLIDs(context.Background(), []types.JID{lid})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("missing mapping returned %#v", got)
+		}
+	}
+	if state.queries != 1 {
+		t.Fatalf("missing mapping queried %d times, want 1", state.queries)
 	}
 }

--- a/store/sqlstore/lidmap_test.go
+++ b/store/sqlstore/lidmap_test.go
@@ -1,8 +1,11 @@
 package sqlstore
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestLIDCacheIsBounded(t *testing.T) {
@@ -23,6 +26,28 @@ func TestLIDCacheIsBounded(t *testing.T) {
 	for pn, lid := range cache.pnToLIDCache {
 		if lid != "" && cache.lidToPNCache[lid] != pn {
 			t.Fatalf("inconsistent cache mapping %s -> %s", pn, lid)
+		}
+	}
+}
+
+func TestGetManyPNsForLIDsUsesReverseCache(t *testing.T) {
+	cache := NewCachedLIDMap(nil)
+	cache.cacheFilled = true
+	cache.cacheMappingLocked("100000000000001", "15550000001")
+	cache.cacheMappingLocked("100000000000002", "15550000002")
+
+	lids := []types.JID{
+		types.NewJID("100000000000001", types.HiddenUserServer),
+		types.NewJID("100000000000002", types.HiddenUserServer),
+	}
+	got, err := cache.GetManyPNsForLIDs(context.Background(), lids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, lid := range lids {
+		want := fmt.Sprintf("1555000000%d@s.whatsapp.net", i+1)
+		if got[lid].String() != want {
+			t.Fatalf("phone for %s = %s, want %s", lid, got[lid], want)
 		}
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -208,6 +208,9 @@ type LIDStore interface {
 	GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error)
 	GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error)
 	GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error)
+}
+
+type LIDBatchReverseStore interface {
 	GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -208,6 +208,7 @@ type LIDStore interface {
 	GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error)
 	GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error)
 	GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error)
+	GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error)
 }
 
 type AllSessionSpecificStores interface {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -15,6 +15,25 @@ type blockingDeviceContainer struct {
 	deleteStarted chan struct{}
 }
 
+type legacyLIDStore struct{}
+
+func (*legacyLIDStore) PutManyLIDMappings(context.Context, []LIDMapping) error { return nil }
+func (*legacyLIDStore) PutLIDMapping(context.Context, types.JID, types.JID) error {
+	return nil
+}
+func (*legacyLIDStore) GetPNForLID(context.Context, types.JID) (types.JID, error) {
+	return types.EmptyJID, nil
+}
+func (*legacyLIDStore) GetLIDForPN(context.Context, types.JID) (types.JID, error) {
+	return types.EmptyJID, nil
+}
+func (*legacyLIDStore) GetManyLIDsForPNs(context.Context, []types.JID) (map[types.JID]types.JID, error) {
+	return nil, nil
+}
+
+var _ LIDStore = (*legacyLIDStore)(nil)
+var _ LIDBatchReverseStore = (*NoopStore)(nil)
+
 func (c *blockingDeviceContainer) PutDevice(_ context.Context, device *Device) error {
 	close(c.putStarted)
 	<-c.allowPut


### PR DESCRIPTION
## What

Adds batched reverse LID alias lookup for sets of users.

## Why

Resolving aliases one user at a time creates an N+1 query path in large groups and contact projections.

## Impact

Callers can hydrate optional phone-number aliases in one database round trip while keeping LID as the primary key.

## Checks

- `go test ./...`
- `go vet ./...`

