### PR TITLE
feat: add typed native flow messages

### DIFF
--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -350,7 +350,7 @@ func BuildBusinessAddressMessage(params BusinessAddressMessageParams) (*waE2E.Me
 }
 
 func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message, error) {
-	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 4096) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 256) || !bounded(params.Footer, 256) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
 		return nil, errors.New("invalid business flow message text")
 	}
 	if strings.TrimSpace(params.FlowID) == "" || !bounded(params.FlowID, 256) || strings.TrimSpace(params.FlowToken) == "" || !bounded(params.FlowToken, 8192) {

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -337,7 +337,7 @@ func BuildBusinessNativeFlowButtonsMessage(params BusinessNativeFlowButtonsMessa
 }
 
 func BuildBusinessAddressMessage(params BusinessAddressMessageParams) (*waE2E.Message, error) {
-	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 4096) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 256) || !bounded(params.Footer, 256) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
 		return nil, errors.New("invalid business address message text")
 	}
 	buttonParams, err := json.Marshal(struct {

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -94,6 +94,25 @@ type BusinessNativeFlowButtonsMessageParams struct {
 	ContextInfo *waE2E.ContextInfo
 }
 
+type BusinessAddressMessageParams struct {
+	Body        string
+	ButtonText  string
+	Footer      string
+	ContextInfo *waE2E.ContextInfo
+}
+
+type BusinessFlowMessageParams struct {
+	Body        string
+	ButtonText  string
+	Footer      string
+	FlowID      string
+	FlowToken   string
+	FlowAction  string
+	Screen      string
+	DataJSON    string
+	ContextInfo *waE2E.ContextInfo
+}
+
 func validBusinessOwner(jid types.JID) bool {
 	return !jid.IsEmpty() && jid.User != "" && (jid.Server == types.DefaultUserServer || jid.Server == types.HiddenUserServer)
 }
@@ -315,4 +334,82 @@ func BuildBusinessNativeFlowButtonsMessage(params BusinessNativeFlowButtonsMessa
 		message.Header = &waE2E.ButtonsMessage_Text{Text: params.Title}
 	}
 	return &waE2E.Message{ButtonsMessage: message}, nil
+}
+
+func BuildBusinessAddressMessage(params BusinessAddressMessageParams) (*waE2E.Message, error) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 4096) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 256) || !bounded(params.Footer, 256) {
+		return nil, errors.New("invalid business address message text")
+	}
+	buttonParams, err := json.Marshal(struct {
+		DisplayText string `json:"display_text"`
+	}{DisplayText: params.ButtonText})
+	if err != nil {
+		return nil, fmt.Errorf("marshal business address message: %w", err)
+	}
+	return buildBusinessInteractiveNativeFlow(params.Body, params.Footer, "address_message", string(buttonParams), params.ContextInfo), nil
+}
+
+func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message, error) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 4096) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 256) || !bounded(params.Footer, 256) {
+		return nil, errors.New("invalid business flow message text")
+	}
+	if strings.TrimSpace(params.FlowID) == "" || !bounded(params.FlowID, 256) || strings.TrimSpace(params.FlowToken) == "" || !bounded(params.FlowToken, 8192) {
+		return nil, errors.New("invalid business flow identity")
+	}
+	if params.FlowAction != "navigate" && params.FlowAction != "data_exchange" {
+		return nil, errors.New("invalid business flow action")
+	}
+	if !bounded(params.Screen, 256) || (params.FlowAction == "navigate" && strings.TrimSpace(params.Screen) == "") {
+		return nil, errors.New("invalid business flow screen")
+	}
+	if params.FlowAction == "data_exchange" && (params.Screen != "" || params.DataJSON != "") {
+		return nil, errors.New("data-exchange flow messages cannot include an action payload")
+	}
+	if !bounded(params.DataJSON, 16*1024) {
+		return nil, errors.New("business flow data is too large")
+	}
+	var data map[string]any
+	if params.DataJSON != "" {
+		if err := json.Unmarshal([]byte(params.DataJSON), &data); err != nil || data == nil {
+			return nil, errors.New("business flow data must be a JSON object")
+		}
+	}
+	type actionPayload struct {
+		Screen string         `json:"screen,omitempty"`
+		Data   map[string]any `json:"data,omitempty"`
+	}
+	var payload *actionPayload
+	if params.FlowAction == "navigate" {
+		payload = &actionPayload{Screen: params.Screen, Data: data}
+	}
+	buttonParams, err := json.Marshal(struct {
+		Version       string         `json:"flow_message_version"`
+		Token         string         `json:"flow_token"`
+		ID            string         `json:"flow_id"`
+		CTA           string         `json:"flow_cta"`
+		Action        string         `json:"flow_action"`
+		ActionPayload *actionPayload `json:"flow_action_payload,omitempty"`
+	}{
+		Version: "3", Token: params.FlowToken, ID: params.FlowID, CTA: params.ButtonText, Action: params.FlowAction,
+		ActionPayload: payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal business flow message: %w", err)
+	}
+	return buildBusinessInteractiveNativeFlow(params.Body, params.Footer, "galaxy_message", string(buttonParams), params.ContextInfo), nil
+}
+
+func buildBusinessInteractiveNativeFlow(body, footer, name, buttonParams string, contextInfo *waE2E.ContextInfo) *waE2E.Message {
+	interactive := &waE2E.InteractiveMessage{
+		Body:        &waE2E.InteractiveMessage_Body{Text: proto.String(body)},
+		ContextInfo: contextInfo,
+		InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+			Buttons:        []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{{Name: proto.String(name), ButtonParamsJSON: proto.String(buttonParams)}},
+			MessageVersion: proto.Int32(1),
+		}},
+	}
+	if footer != "" {
+		interactive.Footer = &waE2E.InteractiveMessage_Footer{Text: proto.String(footer)}
+	}
+	return &waE2E.Message{InteractiveMessage: interactive}
 }

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -368,15 +368,15 @@ func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message,
 	if !bounded(params.DataJSON, 16*1024) {
 		return nil, errors.New("business flow data is too large")
 	}
-	var data map[string]any
+	var data map[string]json.RawMessage
 	if params.DataJSON != "" {
 		if err := json.Unmarshal([]byte(params.DataJSON), &data); err != nil || data == nil {
 			return nil, errors.New("business flow data must be a JSON object")
 		}
 	}
 	type actionPayload struct {
-		Screen string         `json:"screen,omitempty"`
-		Data   map[string]any `json:"data,omitempty"`
+		Screen string                     `json:"screen,omitempty"`
+		Data   map[string]json.RawMessage `json:"data,omitempty"`
 	}
 	var payload *actionPayload
 	if params.FlowAction == "navigate" {

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -369,15 +369,17 @@ func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message,
 	if !utf8.ValidString(params.DataJSON) || !bounded(params.DataJSON, 16*1024) {
 		return nil, errors.New("business flow data is too large")
 	}
-	var data map[string]json.RawMessage
+	var data *map[string]json.RawMessage
 	if params.DataJSON != "" {
-		if err := json.Unmarshal([]byte(params.DataJSON), &data); err != nil || data == nil {
+		parsed := make(map[string]json.RawMessage)
+		if err := json.Unmarshal([]byte(params.DataJSON), &parsed); err != nil || parsed == nil {
 			return nil, errors.New("business flow data must be a JSON object")
 		}
+		data = &parsed
 	}
 	type actionPayload struct {
-		Screen string                     `json:"screen,omitempty"`
-		Data   map[string]json.RawMessage `json:"data,omitempty"`
+		Screen string                      `json:"screen,omitempty"`
+		Data   *map[string]json.RawMessage `json:"data,omitempty"`
 	}
 	var payload *actionPayload
 	if params.FlowAction == "navigate" {

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -354,19 +354,19 @@ func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message,
 	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !utf8.ValidString(params.ButtonText) || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
 		return nil, errors.New("invalid business flow message text")
 	}
-	if strings.TrimSpace(params.FlowID) == "" || !bounded(params.FlowID, 256) || strings.TrimSpace(params.FlowToken) == "" || !bounded(params.FlowToken, 8192) {
+	if strings.TrimSpace(params.FlowID) == "" || !utf8.ValidString(params.FlowID) || !bounded(params.FlowID, 256) || strings.TrimSpace(params.FlowToken) == "" || !utf8.ValidString(params.FlowToken) || !bounded(params.FlowToken, 8192) {
 		return nil, errors.New("invalid business flow identity")
 	}
 	if params.FlowAction != "navigate" && params.FlowAction != "data_exchange" {
 		return nil, errors.New("invalid business flow action")
 	}
-	if !bounded(params.Screen, 256) || (params.FlowAction == "navigate" && strings.TrimSpace(params.Screen) == "") {
+	if !utf8.ValidString(params.Screen) || !bounded(params.Screen, 256) || (params.FlowAction == "navigate" && strings.TrimSpace(params.Screen) == "") {
 		return nil, errors.New("invalid business flow screen")
 	}
 	if params.FlowAction == "data_exchange" && (params.Screen != "" || params.DataJSON != "") {
 		return nil, errors.New("data-exchange flow messages cannot include an action payload")
 	}
-	if !bounded(params.DataJSON, 16*1024) {
+	if !utf8.ValidString(params.DataJSON) || !bounded(params.DataJSON, 16*1024) {
 		return nil, errors.New("business flow data is too large")
 	}
 	var data map[string]json.RawMessage

--- a/business_message_builders.go
+++ b/business_message_builders.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"google.golang.org/protobuf/proto"
 
@@ -337,7 +338,7 @@ func BuildBusinessNativeFlowButtonsMessage(params BusinessNativeFlowButtonsMessa
 }
 
 func BuildBusinessAddressMessage(params BusinessAddressMessageParams) (*waE2E.Message, error) {
-	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !utf8.ValidString(params.ButtonText) || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
 		return nil, errors.New("invalid business address message text")
 	}
 	buttonParams, err := json.Marshal(struct {
@@ -350,7 +351,7 @@ func BuildBusinessAddressMessage(params BusinessAddressMessageParams) (*waE2E.Me
 }
 
 func BuildBusinessFlowMessage(params BusinessFlowMessageParams) (*waE2E.Message, error) {
-	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
+	if strings.TrimSpace(params.Body) == "" || !bounded(params.Body, 1024) || strings.TrimSpace(params.ButtonText) == "" || !utf8.ValidString(params.ButtonText) || !bounded(params.ButtonText, 20) || !bounded(params.Footer, 60) {
 		return nil, errors.New("invalid business flow message text")
 	}
 	if strings.TrimSpace(params.FlowID) == "" || !bounded(params.FlowID, 256) || strings.TrimSpace(params.FlowToken) == "" || !bounded(params.FlowToken, 8192) {

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -258,7 +258,7 @@ func TestBuildBusinessAddressMessageMatchesWebGenerator(t *testing.T) {
 func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	msg, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
 		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",
-		FlowAction: "navigate", Screen: "APPOINTMENT", DataJSON: `{"location":"beirut"}`,
+		FlowAction: "navigate", Screen: "APPOINTMENT", DataJSON: `{"location":"beirut","order_id":9007199254740993}`,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -277,6 +277,17 @@ func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	payload := params["flow_action_payload"].(map[string]any)
 	if payload["screen"] != "APPOINTMENT" || payload["data"].(map[string]any)["location"] != "beirut" {
 		t.Fatalf("unexpected action payload: %#v", payload)
+	}
+	var exact struct {
+		ActionPayload struct {
+			Data map[string]json.RawMessage `json:"data"`
+		} `json:"flow_action_payload"`
+	}
+	if err := json.Unmarshal([]byte(flow.GetButtons()[0].GetButtonParamsJSON()), &exact); err != nil {
+		t.Fatal(err)
+	}
+	if string(exact.ActionPayload.Data["order_id"]) != "9007199254740993" {
+		t.Fatalf("order ID lost precision: %s", exact.ActionPayload.Data["order_id"])
 	}
 }
 

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -1,6 +1,7 @@
 package whatsmeow
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -233,6 +234,52 @@ func TestBusinessListBuildersRejectOversizedSectionsBeforeAllocating(t *testing.
 	}
 }
 
+func TestBuildBusinessAddressMessageMatchesWebGenerator(t *testing.T) {
+	msg, err := BuildBusinessAddressMessage(BusinessAddressMessageParams{
+		Body: "Where should we deliver?", ButtonText: "Share address", Footer: "Synthetic checkout",
+		ContextInfo: &waE2E.ContextInfo{StanzaID: testPtr("quoted-message")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	interactive := msg.GetInteractiveMessage()
+	flow := interactive.GetNativeFlowMessage()
+	if interactive.GetBody().GetText() != "Where should we deliver?" || interactive.GetFooter().GetText() != "Synthetic checkout" {
+		t.Fatalf("unexpected address envelope: %#v", interactive)
+	}
+	if len(flow.GetButtons()) != 1 || flow.GetButtons()[0].GetName() != "address_message" || flow.GetButtons()[0].GetButtonParamsJSON() != `{"display_text":"Share address"}` {
+		t.Fatalf("unexpected address native flow: %#v", flow)
+	}
+	if flow.GetMessageVersion() != 1 || interactive.GetContextInfo().GetStanzaID() != "quoted-message" {
+		t.Fatalf("unexpected address metadata: %#v", interactive)
+	}
+}
+
+func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
+	msg, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
+		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",
+		FlowAction: "navigate", Screen: "APPOINTMENT", DataJSON: `{"location":"beirut"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flow := msg.GetInteractiveMessage().GetNativeFlowMessage()
+	if len(flow.GetButtons()) != 1 || flow.GetButtons()[0].GetName() != "galaxy_message" || flow.GetMessageVersion() != 1 {
+		t.Fatalf("unexpected galaxy flow: %#v", flow)
+	}
+	var params map[string]any
+	if err := json.Unmarshal([]byte(flow.GetButtons()[0].GetButtonParamsJSON()), &params); err != nil {
+		t.Fatal(err)
+	}
+	if params["flow_message_version"] != "3" || params["flow_id"] != "flow-100" || params["flow_token"] != "synthetic-token" || params["flow_cta"] != "Choose a time" || params["flow_action"] != "navigate" {
+		t.Fatalf("unexpected flow params: %#v", params)
+	}
+	payload := params["flow_action_payload"].(map[string]any)
+	if payload["screen"] != "APPOINTMENT" || payload["data"].(map[string]any)["location"] != "beirut" {
+		t.Fatalf("unexpected action payload: %#v", payload)
+	}
+}
+
 func TestBusinessMessageBuildersRejectUnsafeInputs(t *testing.T) {
 	if _, err := BuildBusinessProductMessage(BusinessProductMessageParams{ProductID: "p", Title: "Tea", CurrencyCode: "USD"}); err == nil {
 		t.Fatal("expected missing owner to fail")
@@ -283,6 +330,14 @@ func TestBusinessMessageBuildersRejectUnsafeInputs(t *testing.T) {
 		Body: "Choose", Buttons: []BusinessNativeFlowButton{{Name: "cta_url", ParamsJSON: "not-json"}},
 	}); err == nil {
 		t.Fatal("expected malformed native-flow parameters to fail")
+	}
+	if _, err := BuildBusinessAddressMessage(BusinessAddressMessageParams{Body: "Address", ButtonText: ""}); err == nil {
+		t.Fatal("expected empty address CTA to fail")
+	}
+	if _, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
+		Body: "Flow", ButtonText: "Open", FlowID: "flow", FlowToken: "token", FlowAction: "navigate", DataJSON: `[]`,
+	}); err == nil {
+		t.Fatal("expected non-object flow data to fail")
 	}
 }
 

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -255,6 +255,22 @@ func TestBuildBusinessAddressMessageMatchesWebGenerator(t *testing.T) {
 	}
 }
 
+func TestBusinessAddressMessageEnforcesInteractiveTextLimits(t *testing.T) {
+	valid := BusinessAddressMessageParams{Body: "Address", ButtonText: "Share", Footer: "Footer"}
+	tests := map[string]BusinessAddressMessageParams{
+		"body":   {Body: strings.Repeat("b", 1025), ButtonText: valid.ButtonText, Footer: valid.Footer},
+		"button": {Body: valid.Body, ButtonText: strings.Repeat("c", 21), Footer: valid.Footer},
+		"footer": {Body: valid.Body, ButtonText: valid.ButtonText, Footer: strings.Repeat("f", 61)},
+	}
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildBusinessAddressMessage(params); err == nil {
+				t.Fatal("expected address text limit error")
+			}
+		})
+	}
+}
+
 func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	msg, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
 		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -271,6 +271,34 @@ func TestBusinessAddressMessageEnforcesInteractiveTextLimits(t *testing.T) {
 	}
 }
 
+func TestBusinessFlowMessageEnforcesInteractiveTextLimits(t *testing.T) {
+	valid := BusinessFlowMessageParams{
+		Body: "Book a visit", ButtonText: "Choose a time", Footer: "Appointments",
+		FlowID: "flow-100", FlowToken: "synthetic-token", FlowAction: "navigate", Screen: "APPOINTMENT",
+	}
+	tests := map[string]BusinessFlowMessageParams{
+		"body": {
+			Body: strings.Repeat("b", 1025), ButtonText: valid.ButtonText, Footer: valid.Footer,
+			FlowID: valid.FlowID, FlowToken: valid.FlowToken, FlowAction: valid.FlowAction, Screen: valid.Screen,
+		},
+		"button": {
+			Body: valid.Body, ButtonText: strings.Repeat("c", 21), Footer: valid.Footer,
+			FlowID: valid.FlowID, FlowToken: valid.FlowToken, FlowAction: valid.FlowAction, Screen: valid.Screen,
+		},
+		"footer": {
+			Body: valid.Body, ButtonText: valid.ButtonText, Footer: strings.Repeat("f", 61),
+			FlowID: valid.FlowID, FlowToken: valid.FlowToken, FlowAction: valid.FlowAction, Screen: valid.Screen,
+		},
+	}
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildBusinessFlowMessage(params); err == nil {
+				t.Fatal("expected flow text limit error")
+			}
+		})
+	}
+}
+
 func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	msg, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
 		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -364,6 +364,37 @@ func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	}
 }
 
+func TestBuildBusinessFlowMessagePreservesExplicitEmptyData(t *testing.T) {
+	base := BusinessFlowMessageParams{
+		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",
+		FlowAction: "navigate", Screen: "APPOINTMENT",
+	}
+	for name, dataJSON := range map[string]string{"omitted": "", "empty": `{}`} {
+		t.Run(name, func(t *testing.T) {
+			params := base
+			params.DataJSON = dataJSON
+			msg, err := BuildBusinessFlowMessage(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var encoded struct {
+				ActionPayload map[string]json.RawMessage `json:"flow_action_payload"`
+			}
+			buttonJSON := msg.GetInteractiveMessage().GetNativeFlowMessage().GetButtons()[0].GetButtonParamsJSON()
+			if err := json.Unmarshal([]byte(buttonJSON), &encoded); err != nil {
+				t.Fatal(err)
+			}
+			data, present := encoded.ActionPayload["data"]
+			if dataJSON == "" && present {
+				t.Fatalf("omitted data encoded as %s", data)
+			}
+			if dataJSON != "" && (!present || string(data) != `{}`) {
+				t.Fatalf("explicit empty data encoded as %s", data)
+			}
+		})
+	}
+}
+
 func TestBusinessMessageBuildersRejectUnsafeInputs(t *testing.T) {
 	if _, err := BuildBusinessProductMessage(BusinessProductMessageParams{ProductID: "p", Title: "Tea", CurrencyCode: "USD"}); err == nil {
 		t.Fatal("expected missing owner to fail")

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -423,6 +423,11 @@ func TestBusinessMessageBuildersRejectUnsafeInputs(t *testing.T) {
 	}); err == nil {
 		t.Fatal("expected non-object flow data to fail")
 	}
+	if _, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
+		Body: "Flow", ButtonText: "Open", FlowID: "flow", FlowToken: "token", FlowAction: "navigate", Screen: "START", DataJSON: `{} {}`,
+	}); err == nil {
+		t.Fatal("expected trailing flow JSON to fail")
+	}
 }
 
 func TestBusinessProductListAndNativeFlowTextLimits(t *testing.T) {

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -304,6 +304,30 @@ func TestBusinessFlowMessageEnforcesInteractiveTextLimits(t *testing.T) {
 	}
 }
 
+func TestBusinessFlowMessageRejectsInvalidUTF8PayloadFields(t *testing.T) {
+	valid := BusinessFlowMessageParams{
+		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",
+		FlowAction: "navigate", Screen: "APPOINTMENT", DataJSON: `{"location":"beirut"}`,
+	}
+	tests := map[string]func(*BusinessFlowMessageParams){
+		"flow-id":    func(params *BusinessFlowMessageParams) { params.FlowID = string([]byte{0xff}) },
+		"flow-token": func(params *BusinessFlowMessageParams) { params.FlowToken = string([]byte{0xff}) },
+		"screen":     func(params *BusinessFlowMessageParams) { params.Screen = string([]byte{0xff}) },
+		"data": func(params *BusinessFlowMessageParams) {
+			params.DataJSON = "{\"key\":\"" + string([]byte{0xff}) + "\"}"
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := valid
+			mutate(&params)
+			if _, err := BuildBusinessFlowMessage(params); err == nil {
+				t.Fatal("expected invalid UTF-8 error")
+			}
+		})
+	}
+}
+
 func TestBuildBusinessFlowMessageMatchesWebGenerator(t *testing.T) {
 	msg, err := BuildBusinessFlowMessage(BusinessFlowMessageParams{
 		Body: "Book a visit", ButtonText: "Choose a time", FlowID: "flow-100", FlowToken: "synthetic-token",

--- a/business_message_builders_test.go
+++ b/business_message_builders_test.go
@@ -258,9 +258,10 @@ func TestBuildBusinessAddressMessageMatchesWebGenerator(t *testing.T) {
 func TestBusinessAddressMessageEnforcesInteractiveTextLimits(t *testing.T) {
 	valid := BusinessAddressMessageParams{Body: "Address", ButtonText: "Share", Footer: "Footer"}
 	tests := map[string]BusinessAddressMessageParams{
-		"body":   {Body: strings.Repeat("b", 1025), ButtonText: valid.ButtonText, Footer: valid.Footer},
-		"button": {Body: valid.Body, ButtonText: strings.Repeat("c", 21), Footer: valid.Footer},
-		"footer": {Body: valid.Body, ButtonText: valid.ButtonText, Footer: strings.Repeat("f", 61)},
+		"body":        {Body: strings.Repeat("b", 1025), ButtonText: valid.ButtonText, Footer: valid.Footer},
+		"button":      {Body: valid.Body, ButtonText: strings.Repeat("c", 21), Footer: valid.Footer},
+		"button-utf8": {Body: valid.Body, ButtonText: string([]byte{0xff}), Footer: valid.Footer},
+		"footer":      {Body: valid.Body, ButtonText: valid.ButtonText, Footer: strings.Repeat("f", 61)},
 	}
 	for name, params := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -283,6 +284,10 @@ func TestBusinessFlowMessageEnforcesInteractiveTextLimits(t *testing.T) {
 		},
 		"button": {
 			Body: valid.Body, ButtonText: strings.Repeat("c", 21), Footer: valid.Footer,
+			FlowID: valid.FlowID, FlowToken: valid.FlowToken, FlowAction: valid.FlowAction, Screen: valid.Screen,
+		},
+		"button-utf8": {
+			Body: valid.Body, ButtonText: string([]byte{0xff}), Footer: valid.Footer,
 			FlowID: valid.FlowID, FlowToken: valid.FlowToken, FlowAction: valid.FlowAction, Screen: valid.Screen,
 		},
 		"footer": {

--- a/send.go
+++ b/send.go
@@ -996,10 +996,33 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 		return "buttons"
 	case msg.ListMessage != nil:
 		return "list"
+	case msg.InteractiveMessage != nil && msg.InteractiveMessage.GetNativeFlowMessage() != nil:
+		return "native_flow"
 	case msg.InteractiveResponseMessage != nil:
 		return "interactive_response"
 	default:
 		return ""
+	}
+}
+
+func buildNativeFlowBizNode(msg *waE2E.Message, nowUnix int64) waBinary.Node {
+	name := "mixed"
+	if interactive := msg.GetInteractiveMessage(); interactive != nil {
+		if buttons := interactive.GetNativeFlowMessage().GetButtons(); len(buttons) > 0 && buttons[0].GetName() != "" {
+			name = buttons[0].GetName()
+		}
+	}
+	return waBinary.Node{
+		Tag: "biz",
+		Attrs: waBinary.Attrs{
+			"actual_actors":   "2",
+			"host_storage":    "2",
+			"privacy_mode_ts": strconv.FormatInt(nowUnix, 10),
+		},
+		Content: []waBinary.Node{
+			{Tag: "interactive", Attrs: waBinary.Attrs{"type": "native_flow", "v": "1"}, Content: []waBinary.Node{{Tag: "native_flow", Attrs: waBinary.Attrs{"name": name, "v": "9"}}}},
+			{Tag: "quality_control", Attrs: waBinary.Attrs{"source_type": "third_party"}},
+		},
 	}
 }
 
@@ -1142,13 +1165,17 @@ func (cli *Client) getMessageContent(
 	}
 
 	if buttonType := getButtonTypeFromMessage(message); buttonType != "" {
-		content = append(content, waBinary.Node{
-			Tag: "biz",
-			Content: []waBinary.Node{{
-				Tag:   buttonType,
-				Attrs: getButtonAttributes(message),
-			}},
-		})
+		if buttonType == "native_flow" {
+			content = append(content, buildNativeFlowBizNode(message, time.Now().Unix()))
+		} else {
+			content = append(content, waBinary.Node{
+				Tag: "biz",
+				Content: []waBinary.Node{{
+					Tag:   buttonType,
+					Attrs: getButtonAttributes(message),
+				}},
+			})
+		}
 	}
 	return content
 }

--- a/send.go
+++ b/send.go
@@ -1026,7 +1026,14 @@ func buildNativeFlowBizNode(msg *waE2E.Message, nowUnix int64) waBinary.Node {
 unwrapped:
 	if interactive := msg.GetInteractiveMessage(); interactive != nil {
 		if buttons := interactive.GetNativeFlowMessage().GetButtons(); len(buttons) > 0 && buttons[0].GetName() != "" {
-			name = buttons[0].GetName()
+			candidate := buttons[0].GetName()
+			name = candidate
+			for _, button := range buttons[1:] {
+				if button.GetName() != candidate {
+					name = "mixed"
+					break
+				}
+			}
 		}
 	}
 	return waBinary.Node{

--- a/send.go
+++ b/send.go
@@ -1049,6 +1049,8 @@ func getButtonAttributes(msg *waE2E.Message) waBinary.Attrs {
 		return getButtonAttributes(msg.ViewOnceMessage.Message)
 	case msg.ViewOnceMessageV2 != nil:
 		return getButtonAttributes(msg.ViewOnceMessageV2.Message)
+	case msg.ViewOnceMessageV2Extension != nil:
+		return getButtonAttributes(msg.ViewOnceMessageV2Extension.Message)
 	case msg.EphemeralMessage != nil:
 		return getButtonAttributes(msg.EphemeralMessage.Message)
 	case msg.TemplateMessage != nil:

--- a/send.go
+++ b/send.go
@@ -990,6 +990,8 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 		return getButtonTypeFromMessage(msg.ViewOnceMessage.Message)
 	case msg.ViewOnceMessageV2 != nil:
 		return getButtonTypeFromMessage(msg.ViewOnceMessageV2.Message)
+	case msg.ViewOnceMessageV2Extension != nil:
+		return getButtonTypeFromMessage(msg.ViewOnceMessageV2Extension.Message)
 	case msg.EphemeralMessage != nil:
 		return getButtonTypeFromMessage(msg.EphemeralMessage.Message)
 	case msg.ButtonsMessage != nil:
@@ -1013,6 +1015,8 @@ func buildNativeFlowBizNode(msg *waE2E.Message, nowUnix int64) waBinary.Node {
 			msg = msg.ViewOnceMessage.Message
 		case msg.ViewOnceMessageV2 != nil:
 			msg = msg.ViewOnceMessageV2.Message
+		case msg.ViewOnceMessageV2Extension != nil:
+			msg = msg.ViewOnceMessageV2Extension.Message
 		case msg.EphemeralMessage != nil:
 			msg = msg.EphemeralMessage.Message
 		default:

--- a/send.go
+++ b/send.go
@@ -1007,6 +1007,19 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 
 func buildNativeFlowBizNode(msg *waE2E.Message, nowUnix int64) waBinary.Node {
 	name := "mixed"
+	for msg != nil {
+		switch {
+		case msg.ViewOnceMessage != nil:
+			msg = msg.ViewOnceMessage.Message
+		case msg.ViewOnceMessageV2 != nil:
+			msg = msg.ViewOnceMessageV2.Message
+		case msg.EphemeralMessage != nil:
+			msg = msg.EphemeralMessage.Message
+		default:
+			goto unwrapped
+		}
+	}
+unwrapped:
 	if interactive := msg.GetInteractiveMessage(); interactive != nil {
 		if buttons := interactive.GetNativeFlowMessage().GetButtons(); len(buttons) > 0 && buttons[0].GetName() != "" {
 			name = buttons[0].GetName()

--- a/send_test.go
+++ b/send_test.go
@@ -53,6 +53,22 @@ func TestInteractiveNativeFlowsRequestNamedBusinessMetadata(t *testing.T) {
 	}
 }
 
+func TestHeterogeneousNativeFlowsRequestMixedBusinessMetadata(t *testing.T) {
+	msg := &waE2E.Message{InteractiveMessage: &waE2E.InteractiveMessage{
+		InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+			Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+				{Name: proto.String("quick_reply")},
+				{Name: proto.String("cta_url")},
+			},
+		}},
+	}}
+	biz := buildNativeFlowBizNode(msg, 1_700_000_000)
+	flow := biz.Content.([]waBinary.Node)[0].Content.([]waBinary.Node)[0]
+	if flow.Attrs["name"] != "mixed" {
+		t.Fatalf("native-flow name = %q", flow.Attrs["name"])
+	}
+}
+
 func TestNativeFlowBusinessMetadataUnwrapsMessages(t *testing.T) {
 	inner := &waE2E.Message{InteractiveMessage: &waE2E.InteractiveMessage{
 		InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{

--- a/send_test.go
+++ b/send_test.go
@@ -3,7 +3,9 @@ package whatsmeow
 import (
 	"testing"
 
+	waBinary "go.mau.fi/whatsmeow/binary"
 	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestButtonAndListResponsesDoNotRequestBusinessMetadata(t *testing.T) {
@@ -18,6 +20,33 @@ func TestButtonAndListResponsesDoNotRequestBusinessMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := getButtonTypeFromMessage(tc.msg); got != "" {
 				t.Fatalf("response requested unexpected business metadata type %q", got)
+			}
+		})
+	}
+}
+
+func TestInteractiveNativeFlowsRequestNamedBusinessMetadata(t *testing.T) {
+	for _, name := range []string{"address_message", "galaxy_message"} {
+		t.Run(name, func(t *testing.T) {
+			msg := &waE2E.Message{InteractiveMessage: &waE2E.InteractiveMessage{
+				InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{{Name: proto.String(name)}},
+				}},
+			}}
+			if got := getButtonTypeFromMessage(msg); got != "native_flow" {
+				t.Fatalf("button type = %q", got)
+			}
+			biz := buildNativeFlowBizNode(msg, 1_700_000_000)
+			if biz.Tag != "biz" || biz.Attrs["actual_actors"] != "2" || biz.Attrs["host_storage"] != "2" || biz.Attrs["privacy_mode_ts"] != "1700000000" {
+				t.Fatalf("unexpected biz attrs: %#v", biz)
+			}
+			children, ok := biz.Content.([]waBinary.Node)
+			if !ok || len(children) != 2 || children[0].Tag != "interactive" {
+				t.Fatalf("unexpected biz children: %#v", biz.Content)
+			}
+			flowChildren := children[0].Content.([]waBinary.Node)
+			if flowChildren[0].Tag != "native_flow" || flowChildren[0].Attrs["name"] != name || flowChildren[0].Attrs["v"] != "9" {
+				t.Fatalf("unexpected native-flow metadata: %#v", flowChildren[0])
 			}
 		})
 	}

--- a/send_test.go
+++ b/send_test.go
@@ -79,6 +79,16 @@ func TestNativeFlowBusinessMetadataUnwrapsMessages(t *testing.T) {
 	}
 }
 
+func TestListBusinessMetadataUnwrapsViewOnceV2Extension(t *testing.T) {
+	msg := &waE2E.Message{ViewOnceMessageV2Extension: &waE2E.FutureProofMessage{Message: &waE2E.Message{
+		ListMessage: &waE2E.ListMessage{ListType: waE2E.ListMessage_SINGLE_SELECT.Enum()},
+	}}}
+	attrs := getButtonAttributes(msg)
+	if attrs["v"] != "2" || attrs["type"] != "single_select" {
+		t.Fatalf("unexpected list metadata: %#v", attrs)
+	}
+}
+
 func TestSetParticipantHashMismatch(t *testing.T) {
 	tests := []struct {
 		name string

--- a/send_test.go
+++ b/send_test.go
@@ -3,9 +3,10 @@ package whatsmeow
 import (
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	waBinary "go.mau.fi/whatsmeow/binary"
 	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestButtonAndListResponsesDoNotRequestBusinessMetadata(t *testing.T) {

--- a/send_test.go
+++ b/send_test.go
@@ -60,12 +60,16 @@ func TestNativeFlowBusinessMetadataUnwrapsMessages(t *testing.T) {
 		}},
 	}}
 	wrappers := map[string]*waE2E.Message{
-		"view once":    {ViewOnceMessage: &waE2E.FutureProofMessage{Message: inner}},
-		"view once v2": {ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: inner}},
-		"ephemeral":    {EphemeralMessage: &waE2E.FutureProofMessage{Message: inner}},
+		"view once":              {ViewOnceMessage: &waE2E.FutureProofMessage{Message: inner}},
+		"view once v2":           {ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: inner}},
+		"view once v2 extension": {ViewOnceMessageV2Extension: &waE2E.FutureProofMessage{Message: inner}},
+		"ephemeral":              {EphemeralMessage: &waE2E.FutureProofMessage{Message: inner}},
 	}
 	for name, message := range wrappers {
 		t.Run(name, func(t *testing.T) {
+			if got := getButtonTypeFromMessage(message); got != "native_flow" {
+				t.Fatalf("button type = %q", got)
+			}
 			biz := buildNativeFlowBizNode(message, 1_700_000_000)
 			flow := biz.Content.([]waBinary.Node)[0].Content.([]waBinary.Node)[0]
 			if flow.Attrs["name"] != "galaxy_message" {

--- a/send_test.go
+++ b/send_test.go
@@ -53,6 +53,28 @@ func TestInteractiveNativeFlowsRequestNamedBusinessMetadata(t *testing.T) {
 	}
 }
 
+func TestNativeFlowBusinessMetadataUnwrapsMessages(t *testing.T) {
+	inner := &waE2E.Message{InteractiveMessage: &waE2E.InteractiveMessage{
+		InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+			Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{{Name: proto.String("galaxy_message")}},
+		}},
+	}}
+	wrappers := map[string]*waE2E.Message{
+		"view once":    {ViewOnceMessage: &waE2E.FutureProofMessage{Message: inner}},
+		"view once v2": {ViewOnceMessageV2: &waE2E.FutureProofMessage{Message: inner}},
+		"ephemeral":    {EphemeralMessage: &waE2E.FutureProofMessage{Message: inner}},
+	}
+	for name, message := range wrappers {
+		t.Run(name, func(t *testing.T) {
+			biz := buildNativeFlowBizNode(message, 1_700_000_000)
+			flow := biz.Content.([]waBinary.Node)[0].Content.([]waBinary.Node)[0]
+			if flow.Attrs["name"] != "galaxy_message" {
+				t.Fatalf("native-flow name = %q", flow.Attrs["name"])
+			}
+		})
+	}
+}
+
 func TestSetParticipantHashMismatch(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- add bounded address_message and galaxy_message builders
- emit the native-flow business stanza used by WhatsApp Web
- validate Flow action payloads before protobuf construction

## Verification
- go test ./...

## Scope
This adds linked-device message construction only. It does not implement Cloud API Flow creation, publishing, endpoint encryption, or data-exchange hosting.