### PR TITLE
Retract all semantic versions and document main-only installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@ All notable HyperMeow changes are documented here. HyperMeow uses commit pseudo-
 - Consolidated the root white-box test suite into themed files without removing tests or changing coverage.
 - Consolidated handwritten business-app features into `business.go` without changing the exported API.
 - Moved committed benchmark reports and heap profiles into `benchmark/barback/testdata/results`; fresh run output remains under the ignored `benchmark/barback/results` workspace.
-- Retracted the accidental `v0.1.0` tag and its correction carrier.
-- Kept `v0.0.0` as the only selectable tag; use `@main` for the newest reviewed commit.
-- Established `main` as the sole package source; `dev` remains an integration branch.
+- Retracted every published semantic version; use `@main` for reviewed commits.
+- Established `main` as the sole production source; `dev` remains experimental.
 
 ## First public release - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,20 @@ Install the newest reviewed commit from the authoritative `main` branch:
 go get github.com/polymorfa/hypermeow@main
 ```
 
-The `main` query resolves to a commit pseudo-version. After the version correction,
-`v0.0.0` is the only selectable tagged version. `dev` is an integration branch and
-is never a publication source.
+The `main` query resolves to a commit pseudo-version. Pin the resulting
+pseudo-version in `go.mod` for reproducible builds. Every published semantic
+version is retracted: do not install HyperMeow with `@latest`, a version tag, or
+any feature branch.
+
+To experiment with changes that have not reached `main`, use the integration
+branch explicitly:
+
+```sh
+go get github.com/polymorfa/hypermeow@dev
+```
+
+`dev` is unstable and may be rebased. Do not use it in production or publish a
+library that depends on it.
 
 The root package remains named `whatsmeow`, so use an explicit import alias:
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.25.0
 toolchain go1.26.5
 
 retract (
-	v0.1.1 // Retraction carrier only; use @main or v0.0.0.
-	v0.1.0 // Published accidentally; use @main or v0.0.0.
+	v0.1.1 // Retraction carrier only; use @main.
+	v0.1.0 // Published accidentally; use @main.
+	v0.0.0 // Historical initial tag; use @main.
 )
 
 require (


### PR DESCRIPTION
## What changed

- retracts the remaining cached `v0.0.0` release alongside `v0.1.0` and `v0.1.1`
- documents `@main` as the only supported production source
- tells consumers to pin the resolved pseudo-version for reproducible builds
- reserves `@dev` for explicit experiments and warns against production use
- removes changelog language that described `v0.0.0` as selectable

## Why

HyperMeow publishes reviewed commits from `main` through Go pseudo-versions. Cached semantic versions must not be presented as supported installation targets, and feature branches must not be treated as releases.

## Validation

- `pre-commit run --all-files`
- `go test ./...`
- `go mod tidy -diff`
- `git diff --check`

No tag or GitHub release is created or moved by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polymorfa/codesmith/hypermeow/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789067220&installation_model_id=431831&pr_number=36&repository=polymorfa%2Fhypermeow&return_to=https%3A%2F%2Fgithub.com%2Fpolymorfa%2Fhypermeow%2Fpull%2F36&signature=bc7bb362643c9364ec89b37706a49979b37d164e9b82a10353a6227bba4f0a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->